### PR TITLE
Fix make distcheck

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,2 +1,2 @@
 # List of source files which contain translatable strings.
-endless/hello.c
+endless/eoshello.c

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -8,7 +8,7 @@ TEST_FLAGS = @EOS_SDK_CFLAGS@ -I$(top_srcdir)
 TEST_LIBS = @EOS_SDK_LIBS@ $(top_builddir)/libendless-@EOS_SDK_API_VERSION@.la
 
 test_run_tests_SOURCES = \
-	test/run-tests.c \
+	test/run-tests.c test/run-tests.h \
 	test/test-init.c \
 	test/test-hello.c \
 	test/test-application.c \


### PR DESCRIPTION
Header file missing from a _SOURCES declaration, and wrong file name
in POTFILES.in.
[endlessm/eos-sdk#55]
