### PR TITLE
Ensure that Gtk-Doc and GIR doc are enabled for distributions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,18 @@ DISTCHECK_CONFIGURE_FLAGS = --enable-gtk-doc --enable-gir-doc
 CLEANFILES =
 DISTCLEANFILES =
 
+# Make sure that 'make dist' includes documentation
+if CAN_MAKE_DIST
+dist-hook:
+else
+dist-hook:
+	@echo "***"
+	@echo "*** You must configure with --enable-gtk-doc and --enable-gir-doc"
+	@echo "*** to run make dist or make distcheck."
+	@echo "***"
+	@false
+endif
+
 # # # LIBRARY # # #
 
 # Main Open Endless SDK library

--- a/configure.ac
+++ b/configure.ac
@@ -172,6 +172,15 @@ AS_IF([test "x$enable_gir_doc" = "xyes"], [
 		[AC_MSG_ERROR([yelp-build must be installed for --enable-gir-doc])])])
 AM_CONDITIONAL([ENABLE_GIR_DOC], [test "x$enable_gir_doc" = "xyes"])
 
+# For 'make dist' or 'make distcheck', both --enable-gtk-doc and
+# --enable-gir-doc are required
+AC_MSG_CHECKING([whether this configuration allows building distributions])
+can_make_dist=yes
+AM_COND_IF([ENABLE_GTK_DOC], [], [can_make_dist=no])
+AM_COND_IF([ENABLE_GIR_DOC], [], [can_make_dist=no])
+AM_CONDITIONAL([CAN_MAKE_DIST], [test "x$can_make_dist" = "xyes"])
+AC_MSG_RESULT([$can_make_dist])
+
 # Required libraries
 # ------------------
 PKG_CHECK_MODULES([EOS_SDK], [


### PR DESCRIPTION
'make dist' and 'make distcheck' do not work without calling
./configure --enable-gtk-doc --enable-gir-doc.
[endlessm/eos-sdk#86]
