### PR TITLE
Specify old-style serial test runner

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,8 @@ dnl AC_CONFIG_SRCDIR([src/hello.c])
 # Initialize Automake: enable all warnings and do not insist on GNU standards
 # Automake >= 1.11 required for silent rules
 # no-portability suppresses warnings about syntax specific to GNU make
-AM_INIT_AUTOMAKE([-Wall -Wno-portability foreign 1.11])
+# serial-tests uses the old-style test suite
+AM_INIT_AUTOMAKE([-Wall -Wno-portability foreign 1.11 serial-tests])
 # Avoid spewing garbage over the terminal ('make V=1' to see the garbage)
 AM_SILENT_RULES([yes])
 # Initialize Libtool; don't build static libraries


### PR DESCRIPTION
Our tests break on the new-style parallel test runner, which is the
default in newer versions of Automake.
[endlessm/eos-sdk#121]
