### PR TITLE
Gjs override for getting the directory of the script being run

### DIFF
--- a/overrides/Endless.js
+++ b/overrides/Endless.js
@@ -1,8 +1,23 @@
+const Gio = imports.gi.Gio;
+
 let Endless;
+
+// Returns the directory that the currently executing JS file resides in
+// This is a silly hack that creates an error and looks at its stack trace
+function getCurrentFileDir() {
+    let e = new Error();
+    let caller = e.stack.split('\n')[1];
+    let pathAndLine = caller.split('@')[1];
+    let path = pathAndLine.split(':')[0];
+
+    // Get full path from GIO
+    return Gio.File.new_for_path(path).get_parent().get_path();
+}
 
 function _init() {
     // this is imports.gi.Endless
     Endless = this;
+    Endless.getCurrentFileDir = getCurrentFileDir;
 
     // Override Endless.PageManager.add() so that you can set child properties
     // at the same time


### PR DESCRIPTION
Code like this is in our english app so a gjs script can be run from any directory and still find other files.  I was about to copy it into the programming app but decided this would lead to some code reduction.

I know this will be part of our app launcher one day, but want to put this here for now? All the apps we have coming up could use it.
