### PR TITLE
Create eos-sdk-webhelper package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -32,3 +32,11 @@ Depends: eos-sdk (= ${binary:Version}),
          eos-pstack-dev
 Description: Open Endless SDK
  Development headers for the Open Endless SDK
+
+Package: eos-sdk-webhelper
+Section: libs
+Architecture: any
+Depends: eos-sdk (= ${binary:Version})
+Description: Open Endless SDK web helper
+ Internal convenience library to simplify creation of web apps using the
+ Open Endless SDK.

--- a/debian/eos-sdk-webhelper.install
+++ b/debian/eos-sdk-webhelper.install
@@ -1,0 +1,1 @@
+usr/share/gjs-1.0/WebHelper.js


### PR DESCRIPTION
This Debian package contains only the WebHelper.js GJS module.
This is a separate package so that it will be easy to find which
HTML-based SDK apps depend on it if we decide to remove it later.

[endlessm/eos-sdk#149]
[endlessm/eos-sdk#149-debian]
