### PR TITLE
'eos-application-manifest' tool with subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ endless/eosresource-private.h
 data/eos-wikipedia-domain.gresource
 wikipedia/config.js
 tools/eos-run-test
+tools/eos-application-manifest/eos-application-manifest
 
 *.py[cod]
 

--- a/tools/Makefile.am.inc
+++ b/tools/Makefile.am.inc
@@ -1,3 +1,31 @@
 # Copyright 2013 Endless Mobile, Inc.
 
-bin_SCRIPTS = tools/eos-run-test
+bin_SCRIPTS = \
+	tools/eos-run-test \
+	tools/eos-application-manifest/eos-application-manifest
+	$(NULL)
+
+# Use the following script to replace $datadir inside the script, as suggested
+# by the Autoconf manual; because $datadir and friends only work inside
+# Makefiles. And as long as we're replacing this, go ahead and replace
+# $PACKAGE_VERSION as well.
+tools_edit = sed \
+	-e 's|@datadir[@]|$(datadir)|g' \
+	-e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g' \
+	$(NULL)
+tools/eos-application-manifest/eos-application-manifest: tools/eos-application-manifest/eos-application-manifest.in Makefile
+	$(AM_V_GEN)$(MKDIR_P) tools/eos-application-manifest && \
+	rm -f $@ $@.tmp && \
+	$(tools_edit) $< >$@.tmp && \
+	chmod +x $@.tmp && \
+	chmod a-w $@.tmp && \
+	mv $@.tmp $@
+
+CLEANFILES += tools/eos-application-manifest/eos-application-manifest
+EXTRA_DIST += tools/eos-application-manifest/eos-application-manifest.in
+
+commandsdir = $(datarootdir)/eos-application-manifest/commands
+dist_commands_DATA = \
+	tools/eos-application-manifest/commands/help.js \
+	tools/eos-application-manifest/commands/version.js \
+	$(NULL)

--- a/tools/eos-application-manifest/commands/help.js
+++ b/tools/eos-application-manifest/commands/help.js
@@ -1,0 +1,47 @@
+// Copyright 2013 Endless Mobile, Inc.
+
+const System = imports.system;
+
+function execute(args) {
+    if (args.length === 0) {
+        print('Usage: %s <command> [<args>]\n'.format(System.programInvocationName));
+        // Query all available subcommands
+        let oldSearchPath = imports.searchPath;
+        imports.searchPath = [commandSearchPath]; // only pick up subcommands
+        let commandsList = [];
+        for (let commandName in imports) {
+            commandsList.push(commandName);
+        }
+        imports.searchPath = oldSearchPath;
+
+        // Print out summary for each subcommand
+        if (commandsList.length === 0)
+            return;
+        print('Summaries of commands:');
+        let maxWidth = commandsList.reduce(function (prev, curr) {
+            return Math.max(curr.length, prev.length);
+        });
+        commandsList.forEach(function (commandName) {
+            let command = imports[commandName];
+            let summary;
+            if (typeof command.summary == 'undefined')
+                summary = 'No information available';
+            else
+                summary = command.summary();
+            print('  %%%ds - %%s'.format(maxWidth).format(commandName, summary));
+        });
+        return;
+    }
+
+    const command = imports[args[0]];
+    command.help();
+}
+
+function summary() {
+    return 'Displays help information about a subcommand';
+}
+
+function help() {
+    print("Displays help information about a subcommand.\n\
+Try '%s help <command-name>'.".format(System.programInvocationName));
+}

--- a/tools/eos-application-manifest/commands/version.js
+++ b/tools/eos-application-manifest/commands/version.js
@@ -1,0 +1,15 @@
+// Copyright 2013 Endless Mobile, Inc.
+
+const System = imports.system;
+
+function execute(args) {
+    print("%s version %s".format(System.programInvocationName, programVersion));
+}
+
+function summary() {
+    return "Version information";
+}
+
+function help() {
+    print("Prints the version and exits.");
+}

--- a/tools/eos-application-manifest/eos-application-manifest.in
+++ b/tools/eos-application-manifest/eos-application-manifest.in
@@ -1,0 +1,47 @@
+#!/usr/bin/gjs
+// Copyright 2013 Endless Mobile, Inc.
+
+const Format = imports.format;
+const System = imports.system;
+
+String.prototype.format = Format.format;
+// monkeypatch System.programInvocationName which is not in this version of GJS
+System.programInvocationName = 'eos-application-manifest';
+
+// Other constants, available from subcommands' code
+const commandSearchPath = "@datadir@/eos-application-manifest/commands";
+const programVersion = "@PACKAGE_VERSION@";
+
+// Import commands from commands/ directory (local first)
+imports.searchPath.unshift(commandSearchPath);
+imports.searchPath.unshift('./commands');
+
+// Must invoke a subcommand
+if (ARGV.length === 0) {
+    // automatically invoke "help" command with no arguments
+    const Help = imports.help;
+    Help.execute([]);
+    // System.exit(1); broken, bugzilla.gnome.org #703826
+    throw new Error();
+}
+
+let command_name = ARGV.shift();
+let command;
+try {
+    command = imports[command_name];
+} catch (e) {
+    if (/No JS module '.*' found in search path/.test(e.message)) {
+        let program_name = System.programInvocationName;
+        printerr("%s: '%s' is not a valid command name. See %s help.".format(
+            program_name, command_name, program_name));
+        // System.exit(1); broken
+        throw new Error();
+    }
+}
+try {
+    command.execute(ARGV);
+} catch (e) {
+    printerr('%s: %s'.format(System.programInvocationName, e.message));
+    // System.exit(1); broken
+    throw e;
+}

--- a/wikipedia/Makefile.am.inc
+++ b/wikipedia/Makefile.am.inc
@@ -5,13 +5,13 @@
 # Create a config.js file with the installed directory locations. Use the
 # following sed script to replace $datadir inside the script, as suggested by
 # the Autoconf manual; because $datadir and friends only work inside Makefiles.
-edit = sed \
+wikipedia_edit = sed \
 	-e 's|@datadir[@]|$(datadir)|g' \
 	$(NULL)
 wikipedia/config.js: wikipedia/config.js.in Makefile
 	$(AM_V_GEN)mkdir -p wikipedia && \
 	rm -f $@ $@.tmp && \
-	$(edit) $< >$@.tmp && \
+	$(wikipedia_edit) $< >$@.tmp && \
 	chmod +x $@.tmp && \
 	chmod a-w $@.tmp && \
 	mv $@.tmp $@


### PR DESCRIPTION
This is the framework for an 'eos-application-manifest' tool with
subcommands as in git. Currently the 'help' and 'version' subcommands
are implemented.
[endlessm/eos-sdk#152]
