### PR TITLE
Fix missing imports

### DIFF
--- a/wikipedia/WikipediaApplication.js
+++ b/wikipedia/WikipediaApplication.js
@@ -1,4 +1,6 @@
 const Endless = imports.gi.Endless;
+const Gdk = imports.gi.Gdk;
+const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 const GObject = imports.gi.GObject;
 const Gio = imports.gi.Gio;

--- a/wikipedia/views/category_button.js
+++ b/wikipedia/views/category_button.js
@@ -1,3 +1,4 @@
+const Gdk = imports.gi.Gdk;
 const GdkPixbuf = imports.gi.GdkPixbuf;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;


### PR DESCRIPTION
This bug was masked because the Brazil app was unnecessarily importing
Gtk and Gdk when it started up.

[endlessm/eos-sdk#222]
