### PR TITLE
Backdrop states of top bar buttons

### DIFF
--- a/data/css/endless-widgets.css
+++ b/data/css/endless-widgets.css
@@ -20,6 +20,10 @@
     icon-shadow: 0px -1px alpha(black, 0.25);
 }
 
+.top-bar .button:backdrop {
+    color: #646464;
+}
+
 .top-bar .button:hover {
     color: #dcdcdc;
     icon-shadow: 0px -1px alpha(black, 0.35);
@@ -36,13 +40,6 @@
         color-stop(0.98, rgb(79, 79, 79)),
         color-stop(0.95, rgb(71, 71, 71)),
         color-stop(0, rgb(67, 67, 67)));
-}
-
-.top-bar .button:backdrop
-.top-bar .button:backdrop:hover,
-.top-bar .button:backdrop:active {
-    color: #646464;
-    icon-shadow: none;
 }
 
 /* Endless action button */


### PR DESCRIPTION
The shadow should be the same as in the non-backdrop state. The colors
in the backdrop+hover and backdrop+active states should be the same as
in the non-backdrop states.

[endlessm/eos-sdk#224]
