### PR TITLE
Set font-weight on title fonts

### DIFF
--- a/data/css/eos-wikipedia-domain.css
+++ b/data/css/eos-wikipedia-domain.css
@@ -2,15 +2,17 @@
     font-family: "Source Sans Pro";
 }
 
-.title.front-page {
+.title {
     font-family: "BentonSans ExtraLight";
-    font-size: 100px;
     color: #ffffff;
     text-shadow: 0px 1px 0px alpha(#23326e, 0.15);
 }
 
+.title.front-page {
+    font-size: 100px;
+}
+
 .title.category.front-page {
-    font-family: "BentonSans ExtraLight";
     font-size: 40px;
 }
 

--- a/wikipedia/views/title_label_view.js
+++ b/wikipedia/views/title_label_view.js
@@ -36,6 +36,9 @@ const TitleLabelView = new Lang.Class({
         });
         this._image = new Gtk.Image();
 
+        let context = this._label.get_style_context()
+        context.add_class(EndlessWikipedia.STYLE_CLASS_TITLE);
+
         this.parent(props);
 
         this.add(this._image);


### PR DESCRIPTION
The proper weight of Benton Sans was not showing up.
[endlessm/eos-sdk#228]
