### PR TITLE
Fixed the sizing of pixbufs in the wikipedia first page

### DIFF
--- a/wikipedia/views/title_label_view.js
+++ b/wikipedia/views/title_label_view.js
@@ -91,17 +91,25 @@ const TitleLabelView = new Lang.Class({
 
     // PRIVATE
 
-    _updateImage: function(res_path, width, height) {
-        let [source_width, source_height] = [width, height];
-        if(width > height)
+    _updateImage: function(res_path, dest_width, dest_height) {
+        let [source_width, source_height] = [dest_width, dest_height];
+        // TODO: We need to get the size of the source image, so right now we
+        // are loading the image twice, once to get the size, and the again at
+        // the proper size. We should eventually use a GdkPixbuf.Loader and
+        // connect to the size-prepared signal, as described in the
+        // documentation
+        let temp_pixbuf = GdkPixbuf.Pixbuf.new_from_resource(res_path);
+        let source_aspect = temp_pixbuf.width / temp_pixbuf.height;
+        let dest_aspect = dest_width / dest_height;
+        if(dest_aspect > source_aspect)
             source_height = -1;
         else
             source_width = -1;
         let source_pixbuf = GdkPixbuf.Pixbuf.new_from_resource_at_scale(res_path,
             source_width, source_height, true);
         let cropped_pixbuf = source_pixbuf;
-        if(width < source_pixbuf.width || height < source_pixbuf.height)
-            cropped_pixbuf = source_pixbuf.new_subpixbuf(0, 0, width, height);
+        if(dest_width < source_pixbuf.width || dest_height < source_pixbuf.height)
+            cropped_pixbuf = source_pixbuf.new_subpixbuf(0, 0, dest_width, dest_height);
         this._image.set_from_pixbuf(cropped_pixbuf);
     }
 });


### PR DESCRIPTION
They are now always sized to cover the allocation they need too. Right
now we are double loading the image, once to get its size, which we
should change in the future
[endlessm/eos-sdk#234]
