### PR TITLE
Adjust margins to deal with broken Benton Sans font

### DIFF
--- a/wikipedia/views/category_button.js
+++ b/wikipedia/views/category_button.js
@@ -10,6 +10,7 @@ const CATEGORY_LABEL_LEFT_MARGIN = 25;  // pixels
 const CATEGORY_LABEL_BOTTOM_MARGIN = 20;  // pixels
 const CATEGORY_BUTTON_RIGHT_MARGIN = 20;  // pixels
 const CATEGORY_BUTTON_BOTTOM_MARGIN = 20;  // pixels
+const CATEGORY_LABEL_BENTON_SANS_CORRECTION = 0; // pixels
 const _HOVER_ARROW_URI = '/com/endlessm/wikipedia-domain/assets/category_hover_arrow.png';
 
 GObject.ParamFlags.READWRITE = GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE;
@@ -52,14 +53,14 @@ const CategoryButton = new Lang.Class({
         });
         this._label = new Gtk.Label({
             margin_left: CATEGORY_LABEL_LEFT_MARGIN,
-            margin_bottom: CATEGORY_LABEL_BOTTOM_MARGIN,
+            margin_bottom: CATEGORY_LABEL_BOTTOM_MARGIN - CATEGORY_LABEL_BENTON_SANS_CORRECTION,
             hexpand: true,
             halign: Gtk.Align.START
         });
         this._arrow = new Gtk.Image({
             resource: _HOVER_ARROW_URI,
             margin_right: CATEGORY_BUTTON_RIGHT_MARGIN,
-            margin_bottom: CATEGORY_BUTTON_BOTTOM_MARGIN,
+            margin_bottom: CATEGORY_BUTTON_BOTTOM_MARGIN - CATEGORY_LABEL_BENTON_SANS_CORRECTION,
             halign: Gtk.Align.END,
             no_show_all: true
         });

--- a/wikipedia/views/title_label_view.js
+++ b/wikipedia/views/title_label_view.js
@@ -8,6 +8,7 @@ const Utils = imports.utils;
 const TITLE_LABEL_SCREEN_WIDTH_PERCENTAGE = 0.37;
 const TITLE_LABEL_LEFT_MARGIN = 20;  // pixels
 const TITLE_LABEL_BOTTOM_MARGIN = 20;  // pixels
+const TITLE_LABEL_BENTON_SANS_CORRECTION = 20; // pixels
 
 const TitleLabelView = new Lang.Class({
     Name: 'TitleLabelView',
@@ -32,7 +33,7 @@ const TitleLabelView = new Lang.Class({
             halign: Gtk.Align.START,
             valign: Gtk.Align.END,
             margin_left: TITLE_LABEL_LEFT_MARGIN,
-            margin_bottom: TITLE_LABEL_BOTTOM_MARGIN
+            margin_bottom: TITLE_LABEL_BOTTOM_MARGIN - TITLE_LABEL_BENTON_SANS_CORRECTION
         });
         this._image = new Gtk.Image();
 


### PR DESCRIPTION
The larger the font size, the bigger the correction needs to be. The
title label cannot go any lower than it is, so the category labels'
correction is actually zero, in order to keep the whole thing aligned.
(The category labels' correction ought to be 10.)

[endlessm/eos-sdk#236]
