### PR TITLE
Added padding to titles so that accents appear

### DIFF
--- a/data/css/eos-wikipedia-domain.css
+++ b/data/css/eos-wikipedia-domain.css
@@ -6,6 +6,7 @@
     font-family: "BentonSans ExtraLight";
     color: #ffffff;
     text-shadow: 0px 1px 0px alpha(#23326e, 0.15);
+    padding-top: 15px;
 }
 
 .title.front-page {
@@ -14,6 +15,7 @@
 
 .title.category.front-page {
     font-size: 40px;
+    padding-top: 9px;
 }
 
 Gjs_ArticleList{


### PR DESCRIPTION
Very hacky fix to make accents appear on front page. We have to do this because
Benton Sans font doesn't correctly render accents on uppercase characters without it
[endlessm/eos-sdk#243]
