### PR TITLE
Word-wrap overly long category title

### DIFF
--- a/wikipedia/widgets/category_button.js
+++ b/wikipedia/widgets/category_button.js
@@ -11,6 +11,7 @@ const CATEGORY_LABEL_BOTTOM_MARGIN = 20;  // pixels
 const CATEGORY_BUTTON_RIGHT_MARGIN = 20;  // pixels
 const CATEGORY_BUTTON_BOTTOM_MARGIN = 20;  // pixels
 const CATEGORY_LABEL_BENTON_SANS_CORRECTION = 0; // pixels
+const CATEGORY_BUTTON_BENTON_SANS_CORRECTION = 10; // pixels
 const _HOVER_ARROW_URI = '/com/endlessm/wikipedia-domain/assets/category_hover_arrow.png';
 const MAIN_CATEGORY_SCREEN_WIDTH_PERCENTAGE = 0.37;
 
@@ -72,14 +73,17 @@ const CategoryButton = new Lang.Class({
             margin_left: CATEGORY_LABEL_LEFT_MARGIN,
             margin_bottom: CATEGORY_LABEL_BOTTOM_MARGIN - CATEGORY_LABEL_BENTON_SANS_CORRECTION,
             hexpand: true,
-            halign: Gtk.Align.START
+            halign: Gtk.Align.START,
+            xalign: 0.0,  // deprecated Gtk.Misc properties; necessary because
+            wrap: true    // "wrap" doesn't respect "halign"
         });
         this._arrow = new Gtk.Image({
             resource: _HOVER_ARROW_URI,
             margin_right: CATEGORY_BUTTON_RIGHT_MARGIN,
-            margin_bottom: CATEGORY_BUTTON_BOTTOM_MARGIN - CATEGORY_LABEL_BENTON_SANS_CORRECTION,
+            margin_bottom: CATEGORY_BUTTON_BOTTOM_MARGIN + CATEGORY_BUTTON_BENTON_SANS_CORRECTION,
             halign: Gtk.Align.END,
-            no_show_all: true
+            valign: Gtk.Align.END,
+            opacity: 0
         });
 
         let context = this._label.get_style_context();
@@ -146,12 +150,12 @@ const CategoryButton = new Lang.Class({
             this._eventbox.connect('enter-notify-event',
                 Lang.bind(this, function(widget, event) {
                     this._eventbox.set_state_flags(Gtk.StateFlags.PRELIGHT, false);
-                    this._arrow.show();
+                    this._arrow.opacity = 1.0;
                 }));
             this._eventbox.connect('leave-notify-event',
                 Lang.bind(this, function(widget, event) {
                     this._eventbox.unset_state_flags(Gtk.StateFlags.PRELIGHT);
-                    this._arrow.hide();
+                    this._arrow.opacity = 0.0;
                 }));
         }
     },


### PR DESCRIPTION
Turn word-wrapping on in the GtkLabel. Set the arrow button's valign
to be END, and add a Benton Sans correction to the arrow button.

[endlessm/eos-sdk#255]
