### PR TITLE
Set prgname rather than wmclass directly

### DIFF
--- a/endless/eosapplication.c
+++ b/endless/eosapplication.c
@@ -146,6 +146,13 @@ eos_application_window_removed (GtkApplication *application,
 }
 
 static void
+on_app_id_set (EosApplication *self)
+{
+  const gchar *id = g_application_get_application_id (G_APPLICATION (self));
+  g_set_prgname (id);
+}
+
+static void
 eos_application_class_init (EosApplicationClass *klass)
 {
   GApplicationClass *g_application_class = G_APPLICATION_CLASS (klass);
@@ -163,6 +170,8 @@ static void
 eos_application_init (EosApplication *self)
 {
   self->priv = APPLICATION_PRIVATE (self);
+  g_signal_connect (self, "notify::application-id",
+                    G_CALLBACK (on_app_id_set), self);
 }
 
 /* Public API */

--- a/endless/eoswindow.c
+++ b/endless/eoswindow.c
@@ -381,11 +381,6 @@ set_application (EosWindow *self,
                "for it to connect to.");
       return;
     }
-
-  /* Application's WM_CLASS hint should be the application ID */
-  const gchar *id;
-  id = g_application_get_application_id (G_APPLICATION (application));
-  gtk_window_set_wmclass (GTK_WINDOW (self), id, id);
 }
 
 static void


### PR DESCRIPTION
Changes were made by Cosimo.
Per Cosimo, applications should not call
gtk_window_set_wmclass directly.
Calls to g_set_prgname will indirectly set the wmclass.

[endlessm/eos-shell#853]
