### PR TITLE
Allowed links in domain specific apps

### DIFF
--- a/wikipedia/PrebuiltArticlesPage.js
+++ b/wikipedia/PrebuiltArticlesPage.js
@@ -30,7 +30,7 @@ const PrebuiltArticlesPage = new Lang.Class({
         this._wiki_view = new EndlessWikipedia.WikipediaWebView({
             expand:true,
             hide_links:true
-        }, []);
+        });
 
         this.parent(props);
 
@@ -39,6 +39,10 @@ const PrebuiltArticlesPage = new Lang.Class({
         // Add style contexts for CSS
         let context = this.get_style_context();
         context.add_class(EndlessWikipedia.STYLE_CLASS_ARTICLES_PAGE);
+    },
+
+    setShowableLinks: function(linked_articles){
+        this._wiki_view.setShowableLinks(linked_articles);
     },
 
     get article_title() {

--- a/wikipedia/PrebuiltWikipediaApplication.js
+++ b/wikipedia/PrebuiltWikipediaApplication.js
@@ -21,7 +21,8 @@ const PrebuiltWikipediaApplication = new Lang.Class({
     vfunc_startup: function() {
         this.parent();
         this._domain_wiki_view = new DomainWikiView.DomainWikiView(this);
-        let filename = this.application_uri;
-        this._domain_wiki_presenter = new DomainWikiPresenter.DomainWikiPresenter(this._domain_wiki_model, this._domain_wiki_view, filename);
+        let app_filename = this.application_uri;
+        let linked_articles_filename = this.linked_articles_uri;
+        this._domain_wiki_presenter = new DomainWikiPresenter.DomainWikiPresenter(this._domain_wiki_model, this._domain_wiki_view, app_filename, linked_articles_filename);
     }
 });

--- a/wikipedia/WikipediaApplication.js
+++ b/wikipedia/WikipediaApplication.js
@@ -33,6 +33,13 @@ const WikipediaApplication = new Lang.Class({
             'Application Base Path',
             'Path to base directory where execution began',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            ''),
+
+        // resource:// URI for the linked articles JSON file
+        'linked-articles-uri': GObject.ParamSpec.string('linked-articles-uri',
+            'Linked articles file URI',
+            'URI for the data file describing which articles can have their links shown',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
             '')
     },
 

--- a/wikipedia/WikipediaWebView.js
+++ b/wikipedia/WikipediaWebView.js
@@ -36,7 +36,7 @@ const WikipediaWebView = new Lang.Class({
             false)
     },
 
-    _init: function(params, links_to_show) {
+    _init: function(params) {
         this.parent(params);
         // For debugging
         //let settings = this.get_settings();
@@ -44,11 +44,14 @@ const WikipediaWebView = new Lang.Class({
         //this.set_settings(settings);
         this.connect('context-menu', Lang.bind(this, function(){return true}));
 
-        this._links_to_show = links_to_show;
         this.connect('decide-policy',
             Lang.bind(this, this._onNavigation));
         this.connect('load-changed',
             Lang.bind(this, this._onLoadChange));
+    },
+
+    setShowableLinks: function(linked_articles){
+        this._links_to_show = linked_articles;
     },
 
     _getFullURL: function(base_url, params){

--- a/wikipedia/models/domain_wiki_model.js
+++ b/wikipedia/models/domain_wiki_model.js
@@ -18,6 +18,14 @@ const DomainWikiModel = new Lang.Class({
         this.parent(params);
     },
 
+    setLinkedArticles:function(articles){
+        this._linked_articles = articles;
+    },
+
+    getLinkedArticles:function(){
+        return this._linked_articles;
+    },
+
     //categories should be a list of category models, already populated with article models.
     addCategories: function(categories){
         this._categories = categories;

--- a/wikipedia/presenters/domain_wiki_presenter.js
+++ b/wikipedia/presenters/domain_wiki_presenter.js
@@ -18,20 +18,22 @@ const DomainWikiPresenter = new Lang.Class({
     Name: "DomainWikiPresenter",
     Extends: GObject.Object,
 
-    _init: function(model, view, filename) {
+    _init: function(model, view, app_filename, linked_articles_filename) {
         this._domain_wiki_model = model;
         this._domain_wiki_view = view;
         this._domain_wiki_view.set_presenter(this)
         this._domain_wiki_view.connect('category-chosen', Lang.bind(this, this._onCategoryClicked));
         this._domain_wiki_view.connect('article-chosen', Lang.bind(this, this._onArticleClicked));
 
-        this.initFromJsonFile(filename);
+        this.initAppInfoFromJsonFile(app_filename);
+        this.initPageRankFromJsonFile(linked_articles_filename);
 
-        let categories = this._domain_wiki_model.getCategories();
+        this._domain_wiki_view.set_categories(this._domain_wiki_model.getCategories());
 
-        this._domain_wiki_view.set_categories(categories);
+        let linked_articles = this._domain_wiki_model.getLinkedArticles();
+        let to_show = linked_articles["app_articles"].concat(linked_articles["extra_linked_articles"]);
+        this._domain_wiki_view.set_showable_links(to_show);
     },
-
 
     initArticleModels: function(articles) {
         let _articles = new Array();
@@ -44,7 +46,12 @@ const DomainWikiPresenter = new Lang.Class({
       return _articles;
     },
 
-    initFromJsonFile: function(filename) {
+    initPageRankFromJsonFile: function(filename){
+        let articles = JSON.parse(Utils.load_file_from_resource(filename));
+        this._domain_wiki_model.setLinkedArticles(articles);
+    },
+
+    initAppInfoFromJsonFile: function(filename) {
         let app_content = JSON.parse(Utils.load_file_from_resource(filename));
         this._lang_code = filename.substring(0, 2);
         let categories = app_content['categories'];

--- a/wikipedia/views/domain_wiki_view.js
+++ b/wikipedia/views/domain_wiki_view.js
@@ -192,6 +192,10 @@ const DomainWikiView = new Lang.Class({
         this._front_page.setCategories(categories);
     },
 
+    set_showable_links: function(linked_articles){
+        this._article_view.setShowableLinks(linked_articles);
+    },
+
     _onCategoryClicked: function(page, title, index) {
         this.emit('category-chosen', title, index);
     },


### PR DESCRIPTION
These are the changes to the wikipedia SDK to allow for certain
showable links in the domain specific apps. The JSON file will specify
which links can be clickable across all articles.

N.B. This will only work if also using the brazil app which includes this commit: https://github.com/endlessm/eos-wikipedia-brazil/commit/7cd488d6ad62110c5dfbc748894c60622753ff69

[endlessm/eos-sdk#282]
