### PR TITLE
Create eos-sdk-webhelper package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -47,3 +47,13 @@ Depends: eos-sdk (= ${binary:Version}),
          gjs
 Description: Open Endless SDK Wikipedia library
  GJS libraries for the Open Endless SDK Wikipedia library
+
+Package: eos-sdk-webhelper
+Section: libs
+Architecture: any
+Depends: eos-sdk (= ${binary:Version}),
+         gjs,
+         gir1.2-webkit-3.0
+Description: Open Endless SDK web helper
+ Internal convenience library to simplify creation of web apps using the
+ Open Endless SDK.

--- a/debian/eos-sdk-webhelper.install
+++ b/debian/eos-sdk-webhelper.install
@@ -1,0 +1,1 @@
+usr/share/gjs-1.0/webhelper.js


### PR DESCRIPTION
This Debian package contains only the WebHelper.js GJS module.
This is a separate package so that it will be easy to find which
HTML-based SDK apps depend on it if we decide to remove it later.

[endlessm/eos-sdk#149]

**NOTE** Review #289 first, otherwise this won't make sense.
