### PR TITLE
Use Automake's parallel test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,7 +117,8 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
-test-results.xml
+*.log
+gtkdoc-test-dummy-file*
 
 # Translations
 *.mo

--- a/Makefile.am
+++ b/Makefile.am
@@ -156,7 +156,6 @@ m4_DATA = \
 include $(top_srcdir)/test/Makefile.am
 
 # Run tests when running 'make check'
-TESTS_ENVIRONMENT = gtester -k -o test-results.xml --verbose
 TESTS = test/run-tests
-
-CLEANFILES += test-results.xml
+LOG_COMPILER = gtester
+AM_LOG_FLAGS = -k --verbose

--- a/autogen.sh
+++ b/autogen.sh
@@ -32,15 +32,6 @@ if test -z "$NOCONFIGURE"; then
     echo "environment."
 fi
 
-am_ver=`automake --version | grep -m 1 -o '[^ ]*$'`
-# Autmake 1.11.x doesn't grasp the 'serial-tests' option. Add a m4 file which
-# defines HAS_SERIAL_TESTS_OPTION so we can keep our configure.ac forward
-# compatible
-case $am_ver in
-    1.11*|1.12*) echo '';;
-    *) echo 'm4_define([HAS_SERIAL_TESTS_OPTION], [1])';;
-esac > m4/serial-tests.m4
-
 # Run the actual tools to prepare the clean checkout
 gtkdocize || exit $?
 autoreconf -fi || exit $?

--- a/configure.ac
+++ b/configure.ac
@@ -36,12 +36,9 @@ AC_INIT([Open Endless SDK], [_EOS_SDK_VERSION_MACRO],
 dnl AC_CONFIG_SRCDIR([src/hello.c])
 # Initialize Automake: enable all warnings and do not insist on GNU standards
 # no-portability suppresses warnings about syntax specific to GNU make
-# If Automake >= 1.13 we need the serial-tests options
-# We use an serial-test.m4 file set up in autogen.sh to test if we need it
-m4_include([m4/serial-tests.m4])
-m4_ifdef([HAS_SERIAL_TESTS_OPTION],
-	[AM_INIT_AUTOMAKE([-Wall -Wno-portability foreign 1.11 serial-tests])],
-	[AM_INIT_AUTOMAKE([-Wall -Wno-portability foreign 1.11])])
+# parallel-tests specifies that we use the new parallel-running test harness.
+# Unlike serial-tests, this option is accepted by Automake 1.11
+AM_INIT_AUTOMAKE([-Wall -Wno-portability foreign 1.11 parallel-tests])
 # Avoid spewing garbage over the terminal ('make V=1' to see the garbage)
 AM_SILENT_RULES([yes])
 # Initialize Libtool; don't build static libraries

--- a/docs/reference/endless/Makefile.am
+++ b/docs/reference/endless/Makefile.am
@@ -86,12 +86,17 @@ EXTRA_DIST +=
 # for --rebuild-sections in $(SCAN_OPTIONS) e.g. $(DOC_MODULE)-sections.txt
 #DISTCLEANFILES +=
 
-# Comment this out if you want 'make check' to test you doc status
-# and run some sanity checks
 if ENABLE_GTK_DOC
-TESTS_ENVIRONMENT = cd $(srcdir) && \
-  DOC_MODULE=$(DOC_MODULE) DOC_MAIN_SGML_FILE=$(DOC_MAIN_SGML_FILE) \
-  SRCDIR=$(abs_srcdir) BUILDDIR=$(abs_builddir)
-TESTS = $(GTKDOC_CHECK)
+AM_TESTS_ENVIRONMENT = \
+	export DOC_MODULE=$(DOC_MODULE); \
+	export DOC_MAIN_SGML_FILE=$(DOC_MAIN_SGML_FILE); \
+	export SRCDIR=$(abs_srcdir); \
+	export BUILDDIR=$(abs_builddir)
+TESTS = gtkdoc-test-dummy-file
+LOG_COMPILER = cd $(srcdir) && $(GTKDOC_CHECK)
+
+# Need a dummy file to feed to GTKDOC_CHECK in the parallel test harness
+gtkdoc-test-dummy-file:
+	$(AM_V_GEN)touch $@
 endif
 


### PR DESCRIPTION
This gets rid of a long-standing workaround and makes it easier to
start using a proper test harness for Javascript unit tests.

Unfortunately, it requires a workaround to be able to run gtkdoc-check
on the documentation, but the workaround is not too bad.

[endlessm/eos-sdk#122]
