### PR TITLE
Put local typelib and lib directories in test environment

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -50,3 +50,10 @@ AM_JS_LOG_FLAGS = \
 	$(NULL)
 LOG_COMPILER = gtester
 AM_LOG_FLAGS = -k --verbose
+
+# Use locally built versions of Endless-0.gir and libraries; this may need to be
+# changed to AM_TESTS_ENVIRONMENT in a future version of Automake
+TESTS_ENVIRONMENT = \
+	export GI_TYPELIB_PATH="$(top_builddir)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH}"; \
+	export LD_LIBRARY_PATH="$(top_builddir)/.libs$${LD_LIBRARY_PATH:+:$$LD_LIBRARY_PATH}"; \
+	$(NULL)


### PR DESCRIPTION
When running the tests, we want them to pick up the local copies of
Endless-0.typelib and libendless-0.so instead of the installed copies.
The tests now also run properly when there are no installed copies.

[endlessm/eos-sdk#321]
