### PR TITLE
Remove screen-size test

### DIFF
--- a/test/test-window.c
+++ b/test/test-window.c
@@ -42,40 +42,6 @@ test_application_not_null (GApplication *app)
 }
 
 static void
-test_screen_size (GApplication *app)
-{
-  GtkWidget *win = eos_window_new (EOS_APPLICATION (app));
-  GdkRectangle screen_size, window_size;
-  GdkScreen *default_screen = gdk_screen_get_default ();
-  gint monitor = 0;
-
-  /* If more than one monitor, find out which one to use */
-  if (gdk_screen_get_n_monitors (default_screen) != 1)
-    {
-      GdkWindow *gdkwindow;
-
-      /* Realize the window so that its GdkWindow is not NULL */
-      gtk_widget_realize (GTK_WIDGET (win));
-      gdkwindow = gtk_widget_get_window (GTK_WIDGET (win));
-      monitor = gdk_screen_get_monitor_at_window (default_screen, gdkwindow);
-    }
-
-  gdk_screen_get_monitor_workarea (default_screen, monitor, &screen_size);
-
-  gtk_widget_show_now (GTK_WIDGET (win));
-
-  while (gtk_events_pending ())
-    gtk_main_iteration ();
-
-  gtk_widget_get_allocation (GTK_WIDGET (win), &window_size);
-
-  g_assert_cmpint (screen_size.width, ==, window_size.width);
-  g_assert_cmpint (screen_size.height, ==, window_size.height);
-
-  gtk_widget_destroy (win);
-}
-
-static void
 test_has_top_bar (GApplication *app)
 {
   GtkWidget *win = eos_window_new (EOS_APPLICATION (app));
@@ -209,7 +175,6 @@ add_window_tests (void)
   ADD_APP_WINDOW_TEST ("/window/assign-application", test_assign_application);
   ADD_APP_WINDOW_TEST ("/window/application-not-null",
                        test_application_not_null);
-  ADD_APP_WINDOW_TEST ("/window/screen-size", test_screen_size);
   ADD_APP_WINDOW_TEST ("/window/has-top-bar", test_has_top_bar);
   ADD_APP_WINDOW_TEST ("/window/has-main-area", test_has_main_area);
   ADD_APP_WINDOW_TEST ("/window/has-default-page-manager",


### PR DESCRIPTION
This test does not apply anymore; previously we set the size of an
EosWindow explicitly to be the screen size, but now we just call
gtk_window_maximize(). A window manager is free to ignore this call, so
we cannot reliably test for it -- e.g. in Jenkins' xvfb environment.

[endlessm/eos-sdk#337]
