### PR TITLE
Use AC_CONFIG_LINKS to copy file into builddir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,6 +226,9 @@ AC_CONFIG_FILES([
 ])
 AC_CONFIG_FILES([tools/eos-run-test], [chmod +x tools/eos-run-test])
 AC_CONFIG_HEADERS([config.h])  dnl Header with system-dependent #defines
+# Make docs/reference/webhelper/eos.css available in the build tree as well as
+# the source tree
+AC_CONFIG_LINKS([docs/reference/webhelper/eos.css:docs/reference/webhelper/eos.css])
 # Do the output
 AC_OUTPUT
 

--- a/docs/reference/webhelper/Makefile.am.inc
+++ b/docs/reference/webhelper/Makefile.am.inc
@@ -1,20 +1,14 @@
 if ENABLE_JS_DOC
 
-# This is for moving eos.css into the NaturalDocs project dir, which is in the
-# build tree rather than the source tree.
-docs/reference/webhelper/eos.css: docs/reference/webhelper/eos.css.in
-	$(AM_V_GEN)$(MKDIR_P) $(@D)
-	cp $< $@
-
 build_naturaldocs_verbose = $(build_naturaldocs_verbose_@AM_V@)
 build_naturaldocs_verbose_ = $(build_naturaldocs_verbose_@AM_DEFAULT_V@)
 build_naturaldocs_verbose_0 = @echo '  DOC    Building WebHelper docs';
 
-docs/reference/webhelper/html/index.html: webhelper/webhelper.js docs/reference/webhelper/eos.css
-	$(build_naturaldocs_verbose)$(MKDIR_P) $(@D) && \
-	naturaldocs -i $(<D) -o HTML $(@D) -p $(@D)/.. -s Default eos -hl All
+docs/reference/webhelper/doc-build.stamp: webhelper/webhelper.js docs/reference/webhelper/eos.css
+	$(build_naturaldocs_verbose)$(MKDIR_P) $(@D)/html && \
+	naturaldocs -i $(<D) -o HTML $(@D)/html -p $(@D) -s Default eos -hl All
 
-all-local: docs/reference/webhelper/html/index.html
+all-local: docs/reference/webhelper/doc-build.stamp
 
 webhelper_extra_clean_files = \
 	docs/reference/webhelper/Data/*.nd \
@@ -22,8 +16,7 @@ webhelper_extra_clean_files = \
 	docs/reference/webhelper/Topics.txt \
 	docs/reference/webhelper/Languages.txt \
 	$(NULL)
-EXTRA_DIST += docs/reference/webhelper/eos.css.in
-CLEANFILES += docs/reference/webhelper/eos.css
+EXTRA_DIST += docs/reference/webhelper/eos.css
 DISTCLEANFILES += \
 	$(webhelper_extra_clean_files) \
 	$(NULL)


### PR DESCRIPTION
Instead of a hacky blah: blah.in cp $< $@ rule.

Also, a stamp file turns out to be necessary for building documentation if
it is included in the distribution; if an up-to-date copy of the
documentation is unpacked into the source tree during make distcheck,
then it does not get remade in the build directory because it is
up-to-date. That causes make distcheck to fail later on, because it can't
copy the documentation from the build tree into the dist tree.

[endlessm/eos-sdk#340]
