### PR TITLE
Domain wiki apps use language code

### DIFF
--- a/wikipedia/PrebuiltArticlesPage.js
+++ b/wikipedia/PrebuiltArticlesPage.js
@@ -41,8 +41,12 @@ const PrebuiltArticlesPage = new Lang.Class({
         context.add_class(EndlessWikipedia.STYLE_CLASS_ARTICLES_PAGE);
     },
 
-    setShowableLinks: function(linked_articles){
+    setShowableLinks: function(linked_articles) {
         this._wiki_view.setShowableLinks(linked_articles);
+    },
+
+    set_lang: function(lang) {
+        this._wiki_view.lang = lang;
     },
 
     get article_title() {

--- a/wikipedia/WikipediaWebView.js
+++ b/wikipedia/WikipediaWebView.js
@@ -33,7 +33,12 @@ const WikipediaWebView = new Lang.Class({
             'Hide article links',
             'A boolean to determine whether links should be shown',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
-            false)
+            false),
+        'lang': GObject.ParamSpec.string('lang',
+            'Language code',
+            'Specifies the language to be used in this wiki webview',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            "")
     },
 
     _init: function(params) {
@@ -71,13 +76,21 @@ const WikipediaWebView = new Lang.Class({
     },
 
     loadArticleByTitle: function(title) {
-        let params = {"title":title, "hideLinks":this.hide_links};
+        let params = {
+            title: title, 
+            hideLinks: this.hide_links, 
+            lang: this.lang
+        };
         let url = this._getFullURL(hostName + getPageByTitleURI, params);
         this.load_uri(url);
     },
 
     loadArticleBySearchQuery: function(query) {
-        let params = {"query":query, "hideLinks":this.hide_links};
+        let params = {
+            query: query,
+            hideLinks: this.hide_links,
+            lang: this.lang
+        };
         let url = this._getFullURL(hostName + getPageByQueryURI, params);
         this.load_uri(url);
     },

--- a/wikipedia/presenters/domain_wiki_presenter.js
+++ b/wikipedia/presenters/domain_wiki_presenter.js
@@ -14,6 +14,12 @@ function _resourceUriToPath(uri) {
     throw new Error('Resource URI did not start with "resource://"');
 }
 
+function _pathnameToLanguage(uri) {
+    let parts = uri.split("/");
+    let filename = parts[parts.length-1];
+    return filename.substring(0, 2);
+}
+
 const DomainWikiPresenter = new Lang.Class({
     Name: "DomainWikiPresenter",
     Extends: GObject.Object,
@@ -53,7 +59,7 @@ const DomainWikiPresenter = new Lang.Class({
 
     initAppInfoFromJsonFile: function(filename) {
         let app_content = JSON.parse(Utils.load_file_from_resource(filename));
-        this._lang_code = filename.substring(0, 2);
+        this._domain_wiki_view.set_lang(_pathnameToLanguage(filename));
         let categories = app_content['categories'];
         let cat_length = categories.length
         let category_models = new Array();

--- a/wikipedia/views/domain_wiki_view.js
+++ b/wikipedia/views/domain_wiki_view.js
@@ -179,6 +179,10 @@ const DomainWikiView = new Lang.Class({
         this._article_view.article_uri = article.uri;
     },
 
+    set_lang: function(lang) {
+        this._article_view.set_lang(lang);
+    },
+
     transition_page: function(transition_type, page_name){
         this._window.page_manager.transition_type = transition_type;
         this._window.page_manager.visible_page_name = page_name;


### PR DESCRIPTION
Previously, domain wiki apps were not sensitive to the language
their articles were in. Now, they get that language from the JSON
file name and use that to tell nodejs which language database to use

[endlessm/eos-sdk#345]
