### PR TITLE
Look for personality file in /etc/EndlessOS

### DIFF
--- a/endless/Makefile.am
+++ b/endless/Makefile.am
@@ -64,7 +64,8 @@ libendless_@EOS_SDK_API_VERSION@_la_CPPFLAGS = \
 	@EOS_SDK_CFLAGS@ \
 	-DG_LOG_DOMAIN=\"EndlessSDK\" \
 	-DCOMPILING_EOS_SDK \
-	-DDATADIR=\""$(datadir)"\"
+	-DDATADIR=\""$(datadir)"\" \
+	-DSYSCONFDIR=\""$(sysconfdir)"\"
 libendless_@EOS_SDK_API_VERSION@_la_CFLAGS = $(AM_CFLAGS)
 libendless_@EOS_SDK_API_VERSION@_la_LIBADD = @EOS_SDK_LIBS@
 libendless_@EOS_SDK_API_VERSION@_la_LDFLAGS = \

--- a/endless/eosinit.c
+++ b/endless/eosinit.c
@@ -84,7 +84,7 @@ eos_get_system_personality (void)
 
       if (tmp == NULL)
         {
-          char *path = g_build_filename (DATADIR,
+          char *path = g_build_filename (SYSCONFDIR,
                                          "EndlessOS",
                                          "personality.txt",
                                          NULL);


### PR DESCRIPTION
The personality file is moving to /etc/EndlessOS/personality.txt
for OSTree, since /usr/share is read-only.

[endlessm/eos-shell#1157]
