### PR TITLE
Themed sdk topbar with the lato font

### DIFF
--- a/data/css/endless-widgets.css
+++ b/data/css/endless-widgets.css
@@ -5,6 +5,9 @@
 /* Endless window top bar */
 
 .top-bar {
+    font-family: "Lato";
+    font-style: bold;
+    font-size: 11px;
     background-image: -gtk-gradient(linear, center top, center bottom,
         from(#464646), to(#1e1e1e));
 }


### PR DESCRIPTION
So the font on all the topbar buttons should have a common look
and feel. Still not foolproof, star selecting widgets inside an
app's css and changing the font family will override this
[endlessm/eos-sdk#358]
