### PR TITLE
Query nodejs with versioned API

### DIFF
--- a/wikipedia/WikipediaWebView.js
+++ b/wikipedia/WikipediaWebView.js
@@ -5,7 +5,7 @@ const Lang = imports.lang;
 const WebKit = imports.gi.WebKit2;
 const Utils = imports.wikipedia.utils;
 
-const hostName = "http://127.0.0.1:3000/"
+const hostName = "http://127.0.0.1:3000/v1/";
 const getPageByTitleURI = "getArticleByTitle?";
 const getPageByQueryURI = "getTopArticleByQuery?";
 const getTitlesByQueryURI = "getArticleTitlesByQuery?";


### PR DESCRIPTION
Make requests to 127.0.0.1:3000/v1 instead of 127.0.0.1:3000. In
addition, make sure the language is set on the wikipedia view,
because v1 of the API requires a lang= parameter.

[endlessm/eos-wikipedia-offline#145]
