### PR TITLE
WikiWebView now takes personality and app_name

### DIFF
--- a/wikipedia/PrebuiltArticlesPage.js
+++ b/wikipedia/PrebuiltArticlesPage.js
@@ -28,8 +28,8 @@ const PrebuiltArticlesPage = new Lang.Class({
 
         // Empty array is placeholder until we get baby page rank
         this._wiki_view = new EndlessWikipedia.WikipediaWebView({
-            expand:true,
-            hide_links:true
+            expand: true,
+            hide_links: true
         });
 
         this.parent(props);
@@ -45,8 +45,12 @@ const PrebuiltArticlesPage = new Lang.Class({
         this._wiki_view.setShowableLinks(linked_articles);
     },
 
-    set_lang: function(lang) {
-        this._wiki_view.lang = lang;
+    set_app_name: function (app_name) {
+        this._wiki_view.app_name = app_name;
+    },
+
+    set_personality: function (personality) {
+        this._wiki_view.system_personality = personality;
     },
 
     get article_title() {

--- a/wikipedia/WikipediaWebView.js
+++ b/wikipedia/WikipediaWebView.js
@@ -34,11 +34,16 @@ const WikipediaWebView = new Lang.Class({
             'A boolean to determine whether links should be shown',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
             false),
-        'lang': GObject.ParamSpec.string('lang',
-            'Language code',
-            'Specifies the language to be used in this wiki webview',
+        'system-personality': GObject.ParamSpec.string('system-personality',
+            'System Personality string',
+            'Specifies the system personality to be used in this wiki webview',
             GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
-            "")
+            ""),
+        'app-name': GObject.ParamSpec.string('app-name',
+            'Application name',
+            'Specifies the application that is using this wiki webview',
+            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+            ""),
     },
 
     _init: function(params) {
@@ -47,7 +52,7 @@ const WikipediaWebView = new Lang.Class({
         //let settings = this.get_settings();
         //settings.set_enable_developer_extras(true);
         //this.set_settings(settings);
-        this.connect('context-menu', Lang.bind(this, function(){return true}));
+        this.connect('context-menu', Lang.bind(this, function() {return true;}));
 
         this.connect('decide-policy',
             Lang.bind(this, this._onNavigation));
@@ -60,12 +65,18 @@ const WikipediaWebView = new Lang.Class({
     },
 
     _getFullURL: function(base_url, params){
+        // We always include personality and
+        // app name on all requests.
+
+        params["personality"] = this.system_personality;
+        params["app_name"] = this.app_name;
         let full_url = base_url;
         for(let key in params){
             full_url += key + "=" + params[key] + "&";
         }
+        // Remove the final '&'
         full_url = full_url.slice(0, -1);
-        return full_url
+        return full_url;
     },
 
     loadArticleByURI: function(uri) {
@@ -79,7 +90,6 @@ const WikipediaWebView = new Lang.Class({
         let params = {
             title: title, 
             hideLinks: this.hide_links, 
-            lang: this.lang
         };
         let url = this._getFullURL(hostName + getPageByTitleURI, params);
         this.load_uri(url);
@@ -89,7 +99,6 @@ const WikipediaWebView = new Lang.Class({
         let params = {
             query: query,
             hideLinks: this.hide_links,
-            lang: this.lang
         };
         let url = this._getFullURL(hostName + getPageByQueryURI, params);
         this.load_uri(url);

--- a/wikipedia/presenters/domain_wiki_presenter.js
+++ b/wikipedia/presenters/domain_wiki_presenter.js
@@ -15,10 +15,13 @@ function _resourceUriToPath(uri) {
     throw new Error('Resource URI did not start with "resource://"');
 }
 
-function _pathnameToLanguage(uri) {
+function _pathnameToAppName(uri) {
     let parts = uri.split("/");
     let filename = parts[parts.length-1];
-    return filename.substring(0, 2);
+    // Split by both dashes and periods in order
+    // to retrieve, e.g. 'health' from 'health-Guatemala.json'
+    let filename_parts = filename.split(/[\-\.]/);
+    return filename_parts[0];
 }
 
 const DomainWikiPresenter = new Lang.Class({
@@ -48,6 +51,12 @@ const DomainWikiPresenter = new Lang.Class({
         let linked_articles = this._model.getLinkedArticles();
         let to_show = linked_articles["app_articles"].concat(linked_articles["extra_linked_articles"]);
         this._view.set_showable_links(to_show);
+
+        let app_name = _pathnameToAppName(app_filename);
+        let personality = Endless.get_system_personality();
+
+        this._view.set_personality(personality);
+        this._view.set_app_name(app_name);
     },
 
     initPageRankFromJsonFile: function(filename){

--- a/wikipedia/views/domain_wiki_view.js
+++ b/wikipedia/views/domain_wiki_view.js
@@ -188,10 +188,6 @@ const DomainWikiView = new Lang.Class({
         this._article_view.article_uri = uri;
     },
 
-    set_lang: function(lang) {
-        this._article_view.set_lang(lang);
-    },
-
     /**
      * Method: show_front_page
      * Transition to the front page of the view
@@ -236,6 +232,14 @@ const DomainWikiView = new Lang.Class({
 
     set_showable_links: function(linked_articles){
         this._article_view.setShowableLinks(linked_articles);
+    },
+
+    set_app_name: function (app_name) {
+        this._article_view.set_app_name(app_name);
+    },
+
+    set_personality: function (personality) {
+        this._article_view.set_personality(personality);
     },
 
     // Proxy signal, respond to front page's 'category-chosen' signal by


### PR DESCRIPTION
Previously, we only had one database so the wiki web view
did not have to pass its app name and personality to node
js API. Now that each app has its own database, this
needs to happen

[endlessm/eos-sdk#377]
