### PR TITLE
Query articles with title, not ID

### DIFF
--- a/wikipedia/PrebuiltArticlesPage.js
+++ b/wikipedia/PrebuiltArticlesPage.js
@@ -68,7 +68,7 @@ const PrebuiltArticlesPage = new Lang.Class({
     set article_uri(value) {
         this._article_uri = value;
         if(value !== null && value !== "") {
-            this._wiki_view.loadArticleByURI(this._article_uri);
+            this._wiki_view.loadArticleByTitle(this._article_title);
         }
     }
 });


### PR DESCRIPTION
This is because the NodeJS server and the database don't know about the
WikiHow artice 'cocinar-arroz'; it is stored as 'Cómo Cocinar Arroz'.

[endlessm/eos-sdk#380]
