### PR TITLE
Issues/403

### DIFF
--- a/wikipedia/widgets/category_button.js
+++ b/wikipedia/widgets/category_button.js
@@ -197,7 +197,12 @@ const CategoryButton = new Lang.Class({
             Gdk.cairo_set_source_pixbuf(cr, this._pixbuf, 0, 0);
             cr.paint();
         }
-        this.parent(cr);
+        let ret = this.parent(cr);
+        // We need to manually call dispose on cairo contexts. This is somewhat related to the bug listed here
+        // https://bugzilla.gnome.org/show_bug.cgi?id=685513 for the shell. We should see if they come up with
+        // a better fix in the future, i.e. fix this through gjs.
+        cr.$dispose();
+        return ret;
     },
 
     // HANDLERS


### PR DESCRIPTION
Reverted old quick fix for memory leak, which was a revert of another commit

Put in the proper fix, which is to call cr.$dispose();
#403
