### PR TITLE
Domain specific apps no longer must specify links

### DIFF
--- a/wikipedia/WikipediaWebView.js
+++ b/wikipedia/WikipediaWebView.js
@@ -116,7 +116,7 @@ const WikipediaWebView = new Lang.Class({
     setAllowedLinks: function(){
         // If you want to show all links, then
         // no point in showing some subset of them as well
-        if(!this.hide_links){
+        if(!this.hide_links || this._links_to_show.length === 0){
             return;
         }
         let str = JSON.stringify(this._links_to_show);

--- a/wikipedia/models/domain_wiki_model.js
+++ b/wikipedia/models/domain_wiki_model.js
@@ -16,6 +16,7 @@ const DomainWikiModel = new Lang.Class({
     _init: function(params) {
         this._articles = [];
         this._mainCategory = null;
+        this._linked_articles = undefined;
         this._categories = {};
         this.parent(params);
     },
@@ -90,7 +91,10 @@ const DomainWikiModel = new Lang.Class({
     },
 
     getLinkedArticles:function(){
-        return this._linked_articles;
+        if(this._linked_articles !== undefined)
+            return this._linked_articles["app_articles"].concat(this._linked_articles["extra_linked_articles"]);
+        else
+            return [];
     },
 
     /**

--- a/wikipedia/presenters/domain_wiki_presenter.js
+++ b/wikipedia/presenters/domain_wiki_presenter.js
@@ -42,14 +42,15 @@ const DomainWikiPresenter = new Lang.Class({
             Lang.bind(this, this._onArticleBackClicked));
 
         this.initAppInfoFromJsonFile(app_filename);
-        this.initPageRankFromJsonFile(linked_articles_filename);
+
+        if(linked_articles_filename !== '')
+            this.initPageRankFromJsonFile(linked_articles_filename);
 
         let firstLevel = this._model.getMainCategory().getSubcategories();
         firstLevel.push(this._model.getMainCategory());
         this._view.set_categories(firstLevel);
 
-        let linked_articles = this._model.getLinkedArticles();
-        let to_show = linked_articles["app_articles"].concat(linked_articles["extra_linked_articles"]);
+        let to_show = this._model.getLinkedArticles();
         this._view.set_showable_links(to_show);
 
         let app_name = _pathnameToAppName(app_filename);


### PR DESCRIPTION
Refactored the process of settings which articles should be linked
such that, if no linked articles JSON is specified, the view will
behave as if hide_links were set to true

[endlessm/eos-sdk#402]
