### PR TITLE
Freed cairo context for BoxWithBg widget

### DIFF
--- a/wikipedia/widgets/BoxWithBg.js
+++ b/wikipedia/widgets/BoxWithBg.js
@@ -6,14 +6,16 @@ const BoxWithBg = new Lang.Class({
     Name: "BoxWithBg",
     Extends: Gtk.Box,
 
-    vfunc_draw: function(cairoContext) {
+    vfunc_draw: function(cr) {
         let width = this.get_allocated_width();
         let height = this.get_allocated_height();
         let context = this.get_style_context();
-        Gtk.render_background(context, cairoContext, 0, 0, width, height);
-        Gtk.render_frame(context, cairoContext, 0, 0, width, height);
+        Gtk.render_background(context, cr, 0, 0, width, height);
+        Gtk.render_frame(context, cr, 0, 0, width, height);
 
-        return this.parent(cairoContext);
+        let ret = this.parent(cr);
+        cr.$dispose();
+        return ret;
     }
 });
 


### PR DESCRIPTION
This widget was used on the category page. Without the call to
$dispose there's a large memory leak each time the category page
is displayed on screen.
[endlessm/eos-sdk#408]
