### PR TITLE
Remove {GTK,GLIB}_CHECK_VERSION

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,10 +76,10 @@ AC_SUBST(EOS_SDK_LT_VERSION_INFO)
 
 # Required versions of libraries
 # Update these whenever you use a function that requires a certain API version
-GLIB_REQUIREMENT="glib-2.0 >= 2.36"
+GLIB_REQUIREMENT="glib-2.0 >= 2.38"
 GOBJECT_REQUIREMENT="gobject-2.0"
 GIO_REQUIREMENT="gio-2.0"
-GTK_REQUIREMENT="gtk+-3.0 >= 3.4"
+GTK_REQUIREMENT="gtk+-3.0 >= 3.10"
 # These go into the pkg-config file as Requires: and Requires.private:
 # (Generally, use Requires.private: instead of Requires:)
 EOS_REQUIRED_MODULES=

--- a/endless/eosflexygrid.c
+++ b/endless/eosflexygrid.c
@@ -63,21 +63,10 @@ enum
   LAST_SIGNAL
 };
 
-#if GLIB_CHECK_VERSION (2, 37, 5)
-
-# define EOS_FLEXY_GRID_GET_PRIV(obj) \
+#define EOS_FLEXY_GRID_GET_PRIV(obj) \
   ((EosFlexyGridPrivate *) eos_flexy_grid_get_instance_private ((EosFlexyGrid *) (obj)))
 
 G_DEFINE_TYPE_WITH_PRIVATE (EosFlexyGrid, eos_flexy_grid, GTK_TYPE_CONTAINER)
-
-#else
-
-# define EOS_FLEXY_GRID_GET_PRIV(obj) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((obj), EOS_TYPE_FLEXY_GRID, EosFlexyGridPrivate))
-
-G_DEFINE_TYPE (EosFlexyGrid, eos_flexy_grid, GTK_TYPE_CONTAINER)
-
-#endif /* GLIB_CHECK_VERSION (2, 37, 5) */
 
 static guint grid_signals[LAST_SIGNAL] = { 0, };
 static GParamSpec *grid_props[LAST_PROP] = { NULL, };
@@ -852,10 +841,6 @@ eos_flexy_grid_finalize (GObject *gobject)
 static void
 eos_flexy_grid_class_init (EosFlexyGridClass *klass)
 {
-#if !GLIB_CHECK_VERSION (2, 37, 5)
-  g_type_class_add_private (klass, sizeof (EosFlexyGridPrivate));
-#endif
-
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   gobject_class->finalize = eos_flexy_grid_finalize;
   gobject_class->set_property = eos_flexy_grid_set_property;

--- a/endless/eosflexygridcell.c
+++ b/endless/eosflexygridcell.c
@@ -21,21 +21,10 @@ typedef struct {
   guint selected : 1;
 } EosFlexyGridCellPrivate;
 
-#if GLIB_CHECK_VERSION (2, 37, 5)
-
-# define EOS_FLEXY_GRID_CELL_GET_PRIV(obj) \
+#define EOS_FLEXY_GRID_CELL_GET_PRIV(obj) \
   ((EosFlexyGridCellPrivate *) eos_flexy_grid_cell_get_instance_private ((EosFlexyGridCell *) (obj)))
 
 G_DEFINE_TYPE_WITH_PRIVATE (EosFlexyGridCell, eos_flexy_grid_cell, GTK_TYPE_BIN)
-
-#else
-
-# define EOS_FLEXY_GRID_CELL_GET_PRIV(obj) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((obj), EOS_TYPE_FLEXY_GRID_CELL, EosFlexyGridCellPrivate))
-
-G_DEFINE_TYPE (EosFlexyGridCell, eos_flexy_grid_cell, GTK_TYPE_BIN)
-
-#endif /* GLIB_CHECK_VERSION (2, 37, 5) */
 
 enum
 {
@@ -90,10 +79,6 @@ eos_flexy_grid_cell_get_property (GObject    *gobject,
 static void
 eos_flexy_grid_cell_class_init (EosFlexyGridCellClass *klass)
 {
-#if !GLIB_CHECK_VERSION (2, 37, 6)
-  g_type_class_add_private (klass, sizeof (EosFlexyGridCellPrivate));
-#endif
-
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
   gobject_class->set_property = eos_flexy_grid_cell_set_property;
   gobject_class->get_property = eos_flexy_grid_cell_get_property;

--- a/endless/eoswindow.c
+++ b/endless/eoswindow.c
@@ -571,36 +571,6 @@ eos_window_class_init (EosWindowClass *klass)
   g_object_class_install_properties (object_class, NPROPS, eos_window_props);
 }
 
-#if GTK_CHECK_VERSION (3, 10, 0)
-#define our_window_close(w)     gtk_window_close (w)
-#else
-static gboolean
-queue_close (gpointer user_data)
-{
-  GtkWidget *window = user_data;
-
-  GdkEvent *event = gdk_event_new (GDK_DELETE);
-
-  event->any.window = gtk_widget_get_window (window);
-  event->any.send_event = TRUE;
-
-  gtk_main_do_event (event);
-
-  gdk_event_free (event);
-
-  return G_SOURCE_REMOVE;
-}
-
-static void
-our_window_close (GtkWindow *window)
-{
-  if (!gtk_widget_get_realized (GTK_WIDGET (window)))
-    return;
-
-  gdk_threads_add_idle (queue_close, window);
-}
-#endif /* GTK_CHECK_VERSION (3, 10, 0) */
-
 static void
 on_minimize_clicked_cb (GtkWidget* top_bar)
 {
@@ -614,7 +584,7 @@ on_close_clicked_cb (GtkWidget* top_bar)
 {
   GtkWidget *window = gtk_widget_get_toplevel (top_bar);
 
-  our_window_close (GTK_WINDOW (window));
+  gtk_window_close (GTK_WINDOW (window));
 }
 
 /* Make sure that the edge finishing does not catch input events */


### PR DESCRIPTION
This removes all conditionally compiled parts for GTK < 3.10 and
GLib < 2.38.

[endlessm/eos-sdk#420]
