### PR TITLE
Only reset Adwaita for widgets inside an EosWindow

### DIFF
--- a/data/css/reset.css
+++ b/data/css/reset.css
@@ -6,7 +6,8 @@
  * Also, when adding new style properties, please add them here.
  */
 
-* {
+EosWindow,
+EosWindow * {
   color: inherit;
   font-size: inherit;
   background-color: initial;


### PR DESCRIPTION
This way popups will still have the Adwaita theme, instead of
looking mainly black
[endlessm/eos-sdk#425]
