### PR TITLE
Use the new way to define private gobject data

### DIFF
--- a/endless/eosactionbutton.c
+++ b/endless/eosactionbutton.c
@@ -34,13 +34,7 @@
 
 #define _EOS_STYLE_CLASS_ACTION_BUTTON "action-button"
 
-G_DEFINE_TYPE (EosActionButton, eos_action_button, GTK_TYPE_BUTTON)
-
-#define EOS_ACTION_BUTTON_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), EOS_TYPE_ACTION_BUTTON, EosActionButtonPrivate))
-
-struct _EosActionButtonPrivate
-{
+typedef struct {
   /* properties */
   EosActionButtonSize size;
   gchar *label;
@@ -51,7 +45,9 @@ struct _EosActionButtonPrivate
   GtkWidget *grid;
   GtkWidget *icon_image;
   GtkWidget *label_widget;
-};
+} EosActionButtonPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (EosActionButton, eos_action_button, GTK_TYPE_BUTTON)
 
 typedef struct _EosActionButtonSizeDefinition EosActionButtonSizeDefinition;
 
@@ -116,8 +112,6 @@ eos_action_button_class_init (EosActionButtonClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
-
-  g_type_class_add_private (klass, sizeof (EosActionButtonPrivate));
 
   object_class->get_property = eos_action_button_get_property;
   object_class->set_property = eos_action_button_set_property;
@@ -224,13 +218,9 @@ eos_action_button_class_init (EosActionButtonClass *klass)
 static void
 eos_action_button_init (EosActionButton *self)
 {
-  EosActionButtonPrivate *priv;
-  GtkStyleContext *context;
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (self);
+  GtkStyleContext *context = gtk_widget_get_style_context (GTK_WIDGET (self));
 
-  self->priv = EOS_ACTION_BUTTON_PRIVATE (self);
-  priv = self->priv;
-
-  context = gtk_widget_get_style_context (GTK_WIDGET (self));
   gtk_style_context_add_class (context, _EOS_STYLE_CLASS_ACTION_BUTTON);
 
   priv->icon_image = gtk_image_new();
@@ -296,11 +286,9 @@ eos_action_button_finalize (GObject *object)
 static void
 eos_action_button_load_icon (EosActionButton *button)
 {
-  EosActionButtonPrivate *priv;
-
   g_return_if_fail (EOS_IS_ACTION_BUTTON (button));
 
-  priv = button->priv;
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (button);
 
   if (priv->icon_id != NULL)
     {
@@ -329,12 +317,10 @@ void
 eos_action_button_set_size  (EosActionButton *button,
                              EosActionButtonSize size)
 {
-  EosActionButtonPrivate *priv;
-  int old_size;
-
   g_return_if_fail (EOS_IS_ACTION_BUTTON (button));
 
-  priv = button->priv;
+  int old_size;
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (button);
 
   old_size = priv->size;
   priv->size = size;
@@ -365,12 +351,9 @@ eos_action_button_set_size  (EosActionButton *button,
 EosActionButtonSize
 eos_action_button_get_size (EosActionButton *button)
 {
-  EosActionButtonPrivate *priv;
-
   g_return_val_if_fail (EOS_IS_ACTION_BUTTON (button), -1);
 
-  priv = button->priv;
-
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (button);
   return priv->size;
 }
 
@@ -385,13 +368,10 @@ eos_action_button_get_size (EosActionButton *button)
 void
 eos_action_button_set_label (EosActionButton *button, const gchar *label)
 {
-  EosActionButtonPrivate *priv;
-  gchar *new_label;
-
   g_return_if_fail (EOS_IS_ACTION_BUTTON (button));
 
-  priv = button->priv;
-  new_label = g_strdup (label);
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (button);
+  gchar *new_label = g_strdup (label);
   g_free (priv->label);
   priv->label = new_label;
 
@@ -412,12 +392,9 @@ eos_action_button_set_label (EosActionButton *button, const gchar *label)
 const gchar *
 eos_action_button_get_label (EosActionButton *button)
 {
-  EosActionButtonPrivate *priv;
-
   g_return_val_if_fail (EOS_IS_ACTION_BUTTON (button), NULL);
 
-  priv = button->priv;
-
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (button);
   return priv->label;
 }
 
@@ -434,11 +411,9 @@ void
 eos_action_button_set_label_position (EosActionButton *button,
                                       GtkPositionType position)
 {
-  EosActionButtonPrivate *priv;
-
   g_return_if_fail (EOS_IS_ACTION_BUTTON (button));
 
-  priv = button->priv;
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (button);
 
   if (priv->label_pos != position)
     {
@@ -479,12 +454,9 @@ eos_action_button_set_label_position (EosActionButton *button,
 GtkPositionType
 eos_action_button_get_label_position (EosActionButton *button)
 {
-  EosActionButtonPrivate *priv;
-
   g_return_val_if_fail (EOS_IS_ACTION_BUTTON (button), -1);
 
-  priv = button->priv;
-
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (button);
   return priv->label_pos;
 }
 
@@ -500,10 +472,8 @@ void
 eos_action_button_set_icon_id (EosActionButton *button,
                                const gchar* icon_id)
 {
-  EosActionButtonPrivate *priv;
-
   g_return_if_fail (EOS_IS_ACTION_BUTTON (button));
-  priv = button->priv;
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (button);
 
   if (g_strcmp0 (icon_id, priv->icon_id) != 0)
     {
@@ -529,7 +499,8 @@ eos_action_button_get_icon_id (EosActionButton *button)
 {
   g_return_val_if_fail (EOS_IS_ACTION_BUTTON (button), NULL);
 
-  return button->priv->icon_id;
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (button);
+  return priv->icon_id;
 }
 
 static void
@@ -539,7 +510,7 @@ eos_action_button_get_property (GObject    *object,
                                 GParamSpec *pspec)
 {
   EosActionButton *button = EOS_ACTION_BUTTON (object);
-  EosActionButtonPrivate *priv = button->priv;
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (button);
 
   switch (property_id)
   {
@@ -596,7 +567,7 @@ eos_action_button_get_real_size (GtkWidget      *widget,
                                  gint           *natural_size)
 {
   EosActionButton *button = EOS_ACTION_BUTTON (widget);
-  EosActionButtonPrivate *priv = button->priv;
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (button);
   GtkBorder margin;
   GtkAllocation label_allocation;
   GtkStyleContext *context = gtk_widget_get_style_context (widget);
@@ -675,7 +646,7 @@ eos_action_button_draw (GtkWidget *widget,
                         cairo_t   *cr)
 {
   EosActionButton *button = EOS_ACTION_BUTTON (widget);
-  EosActionButtonPrivate *priv = button->priv;
+  EosActionButtonPrivate *priv = eos_action_button_get_instance_private (button);
 
   gint x, y;
   gint frame_x = 0, frame_y = 0, bg_x = 0, bg_y = 0, icon_x = 0, icon_y = 0, label_x = 0, label_y = 0;

--- a/endless/eosactionbutton.h
+++ b/endless/eosactionbutton.h
@@ -33,7 +33,6 @@ G_BEGIN_DECLS
 
 typedef struct _EosActionButton EosActionButton;
 typedef struct _EosActionButtonClass EosActionButtonClass;
-typedef struct _EosActionButtonPrivate EosActionButtonPrivate;
 
 /**
  * EosActionButton:
@@ -43,8 +42,6 @@ typedef struct _EosActionButtonPrivate EosActionButtonPrivate;
 struct _EosActionButton
 {
   GtkButton parent;
-
-  EosActionButtonPrivate *priv;
 };
 
 struct _EosActionButtonClass

--- a/endless/eosactionmenu-private.h
+++ b/endless/eosactionmenu-private.h
@@ -33,13 +33,10 @@ G_BEGIN_DECLS
 
 typedef struct _EosActionMenu EosActionMenu;
 typedef struct _EosActionMenuClass EosActionMenuClass;
-typedef struct _EosActionMenuPrivate EosActionMenuPrivate;
 
 struct _EosActionMenu
 {
   GtkFrame parent;
-
-  EosActionMenuPrivate *priv;
 };
 
 struct _EosActionMenuClass

--- a/endless/eosactionmenu.c
+++ b/endless/eosactionmenu.c
@@ -17,19 +17,15 @@
  */
 
 
-G_DEFINE_TYPE (EosActionMenu, eos_action_menu, GTK_TYPE_FRAME)
-
-#define EOS_ACTION_MENU_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), EOS_TYPE_ACTION_MENU, EosActionMenuPrivate))
-
-struct _EosActionMenuPrivate
-{
+typedef struct {
   GtkWidget *overlay;
   GtkWidget *center_grid;
   GtkWidget *bottom_grid;
 
   GtkActionGroup *action_group;
-};
+} EosActionMenuPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (EosActionMenu, eos_action_menu, GTK_TYPE_FRAME)
 
 static void
 eos_action_menu_dispose (GObject *object);
@@ -44,8 +40,6 @@ eos_action_menu_class_init (EosActionMenuClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
-  g_type_class_add_private (klass, sizeof (EosActionMenuPrivate));
-
   object_class->dispose = eos_action_menu_dispose;
   object_class->finalize = eos_action_menu_finalize;
 }
@@ -53,11 +47,8 @@ eos_action_menu_class_init (EosActionMenuClass *klass)
 static void
 eos_action_menu_init (EosActionMenu *self)
 {
-  EosActionMenuPrivate *priv;
+  EosActionMenuPrivate *priv = eos_action_menu_get_instance_private (self);
   GtkStyleContext *context;
-
-  self->priv = EOS_ACTION_MENU_PRIVATE (self);
-  priv = self->priv;
 
   context = gtk_widget_get_style_context (GTK_WIDGET (self));
   gtk_style_context_add_class (context, _EOS_STYLE_CLASS_ACTION_MENU);
@@ -148,11 +139,9 @@ void
 eos_action_menu_add_action (EosActionMenu *menu,
                             GtkAction *action)
 {
-  EosActionMenuPrivate *priv;
-
   g_return_if_fail (EOS_IS_ACTION_MENU (menu));
-  priv = menu->priv;
 
+  EosActionMenuPrivate *priv = eos_action_menu_get_instance_private (menu);
   if (action)
     {
       gtk_action_group_add_action (priv->action_group, action);
@@ -193,9 +182,8 @@ GtkAction *
 eos_action_menu_get_action (EosActionMenu *menu,
                             const gchar *name)
 {
-  EosActionMenuPrivate *priv;
   g_return_val_if_fail (EOS_IS_ACTION_MENU (menu), NULL);
-  priv = menu->priv;
+  EosActionMenuPrivate *priv = eos_action_menu_get_instance_private (menu);
 
   return gtk_action_group_get_action (priv->action_group, name);
 }
@@ -209,9 +197,8 @@ eos_action_menu_get_action (EosActionMenu *menu,
 GList *
 eos_action_menu_list_actions (EosActionMenu *menu)
 {
-  EosActionMenuPrivate *priv;
   g_return_val_if_fail (EOS_IS_ACTION_MENU (menu), NULL);
-  priv = menu->priv;
+  EosActionMenuPrivate *priv = eos_action_menu_get_instance_private (menu);
 
   return gtk_action_group_list_actions (priv->action_group);
 }
@@ -227,13 +214,12 @@ void
 eos_action_menu_remove_action (EosActionMenu *menu,
                                GtkAction *action)
 {
-  EosActionMenuPrivate *priv;
-  GList *children, *i;
-  GtkWidget *target_child = NULL;
-
   g_return_if_fail (EOS_IS_ACTION_MENU (menu));
   g_return_if_fail (GTK_IS_ACTION (action));
-  priv = menu->priv;
+
+  EosActionMenuPrivate *priv = eos_action_menu_get_instance_private (menu);
+  GList *children, *i;
+  GtkWidget *target_child = NULL;
 
   gtk_action_group_remove_action(priv->action_group, action);
 
@@ -272,11 +258,10 @@ void
 eos_action_menu_remove_action_by_name (EosActionMenu *menu,
                                        const gchar *name)
 {
-  GtkAction *action;
-  EosActionMenuPrivate *priv;
-
   g_return_if_fail (EOS_IS_ACTION_MENU (menu));
-  priv = menu->priv;
+
+  GtkAction *action;
+  EosActionMenuPrivate *priv = eos_action_menu_get_instance_private (menu);
 
   action = gtk_action_group_get_action (priv->action_group, name);
   if (action)

--- a/endless/eosapplication.h
+++ b/endless/eosapplication.h
@@ -35,7 +35,6 @@
 
 typedef struct _EosApplication EosApplication;
 typedef struct _EosApplicationClass EosApplicationClass;
-typedef struct _EosApplicationPrivate EosApplicationPrivate;
 
 /**
  * EosApplication:
@@ -46,8 +45,6 @@ struct _EosApplication
 {
   /*< private >*/
   GtkApplication parent;
-
-  EosApplicationPrivate *priv;
 };
 
 struct _EosApplicationClass

--- a/endless/eosflexygrid.c
+++ b/endless/eosflexygrid.c
@@ -63,9 +63,6 @@ enum
   LAST_SIGNAL
 };
 
-#define EOS_FLEXY_GRID_GET_PRIV(obj) \
-  ((EosFlexyGridPrivate *) eos_flexy_grid_get_instance_private ((EosFlexyGrid *) (obj)))
-
 G_DEFINE_TYPE_WITH_PRIVATE (EosFlexyGrid, eos_flexy_grid, GTK_TYPE_CONTAINER)
 
 static guint grid_signals[LAST_SIGNAL] = { 0, };
@@ -75,7 +72,7 @@ static void
 eos_flexy_grid_update_cell_prelight (EosFlexyGrid *grid,
                                      EosFlexyGridCell *cell)
 {
-  EosFlexyGridPrivate *priv = grid->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (grid);
 
   if (cell == priv->prelight_cell)
     return;
@@ -392,7 +389,7 @@ eos_flexy_grid_get_preferred_width (GtkWidget *widget,
                                     gint      *minimum_width_out,
                                     gint      *natural_width_out)
 {
-  EosFlexyGridPrivate *priv = EOS_FLEXY_GRID (widget)->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (EOS_FLEXY_GRID (widget));
   int minimum_width, natural_width;
 
   int target_column_size = priv->cell_size < 0 ? DEFAULT_CELL_SIZE : priv->cell_size;
@@ -462,7 +459,7 @@ eos_flexy_grid_get_preferred_height_for_width (GtkWidget *widget,
                                                gint      *minimum_height_out,
                                                gint      *natural_height_out)
 {
-  EosFlexyGridPrivate *priv = EOS_FLEXY_GRID (widget)->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (EOS_FLEXY_GRID (widget));
 
   int cell_size = priv->cell_size < 0 ? DEFAULT_CELL_SIZE : priv->cell_size;
   int cell_spacing = priv->cell_spacing < 0 ? DEFAULT_SPACING : priv->cell_spacing;
@@ -502,7 +499,7 @@ eos_flexy_grid_size_allocate (GtkWidget     *widget,
                             allocation->width,
                             allocation->height);
 
-  EosFlexyGridPrivate *priv = EOS_FLEXY_GRID (widget)->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (EOS_FLEXY_GRID (widget));
 
   int cell_size = priv->cell_size < 0 ? DEFAULT_CELL_SIZE : priv->cell_size;
   int cell_spacing = priv->cell_spacing < 0 ? DEFAULT_SPACING : priv->cell_spacing;
@@ -575,7 +572,7 @@ eos_flexy_grid_remove (GtkContainer *container,
       return;
     }
 
-  EosFlexyGridPrivate *priv = EOS_FLEXY_GRID (container)->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (EOS_FLEXY_GRID (container));
 
   EosFlexyGridCell *cell = EOS_FLEXY_GRID_CELL (widget);
   GSequenceIter *iter = eos_flexy_grid_cell_get_iter (cell);
@@ -614,7 +611,7 @@ eos_flexy_grid_forall (GtkContainer *container,
                        GtkCallback   callback,
                        gpointer      data)
 {
-  EosFlexyGridPrivate *priv = EOS_FLEXY_GRID (container)->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (EOS_FLEXY_GRID (container));
 
   GSequenceIter *iter = g_sequence_get_begin_iter (priv->children);
   while (!g_sequence_iter_is_end (iter))
@@ -670,7 +667,7 @@ eos_flexy_grid_button_press (GtkWidget *widget,
     return GDK_EVENT_PROPAGATE;
 
   EosFlexyGrid *self = EOS_FLEXY_GRID (widget);
-  EosFlexyGridPrivate *priv = self->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (self);
 
   priv->active_cell = NULL;
 
@@ -717,7 +714,7 @@ eos_flexy_grid_button_release (GtkWidget *widget,
   if (event->button == GDK_BUTTON_PRIMARY)
     {
       EosFlexyGrid *grid = EOS_FLEXY_GRID (widget);
-      EosFlexyGridPrivate *priv = grid->priv;
+      EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (grid);
 
       if (priv->active_cell != NULL)
         {
@@ -742,7 +739,7 @@ eos_flexy_grid_enter_notify (GtkWidget        *widget,
   if (event->window != gtk_widget_get_window (widget))
     return GDK_EVENT_PROPAGATE;
 
-  EosFlexyGridPrivate *priv = EOS_FLEXY_GRID (widget)->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (EOS_FLEXY_GRID (widget));
 
   priv->in_widget = TRUE;
 
@@ -761,7 +758,7 @@ eos_flexy_grid_leave_notify (GtkWidget        *widget,
   if (event->window != gtk_widget_get_window (widget))
     return GDK_EVENT_PROPAGATE;
 
-  EosFlexyGridPrivate *priv = EOS_FLEXY_GRID (widget)->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (EOS_FLEXY_GRID (widget));
   EosFlexyGridCell *cell;
 
   if (event->detail != GDK_NOTIFY_INFERIOR)
@@ -828,7 +825,7 @@ eos_flexy_grid_get_property (GObject    *gobject,
 static void
 eos_flexy_grid_finalize (GObject *gobject)
 {
-  EosFlexyGridPrivate *priv = EOS_FLEXY_GRID (gobject)->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (EOS_FLEXY_GRID (gobject));
 
   if (priv->sort_notify != NULL)
     priv->sort_notify (priv->sort_data);
@@ -935,16 +932,13 @@ eos_flexy_grid_class_init (EosFlexyGridClass *klass)
 static void
 eos_flexy_grid_init (EosFlexyGrid *self)
 {
-  EosFlexyGridPrivate *priv = EOS_FLEXY_GRID_GET_PRIV (self);
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (self);
 
   priv->children = g_sequence_new (NULL);
 
   /* we use the same width as the discovery center layout */
   priv->cell_size = -1;
   priv->cell_spacing = DEFAULT_SPACING;
-
-  /* XXX: once we depend on GTK 3.10 and GLib 2.38, we should remove this */
-  self->priv = priv;
 
   GtkWidget *widget = GTK_WIDGET (self);
   gtk_widget_set_has_window (widget, TRUE);
@@ -995,7 +989,7 @@ eos_flexy_grid_set_sort_func (EosFlexyGrid         *grid,
 {
   g_return_if_fail (EOS_IS_FLEXY_GRID (grid));
 
-  EosFlexyGridPrivate *priv = grid->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (grid);
   if (priv->sort_notify != NULL)
     priv->sort_notify (priv->sort_data);
 
@@ -1019,7 +1013,7 @@ eos_flexy_grid_set_cell_size (EosFlexyGrid *grid,
 {
   g_return_if_fail (EOS_IS_FLEXY_GRID (grid));
 
-  EosFlexyGridPrivate *priv = grid->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (grid);
   if (priv->cell_size == size)
     return;
 
@@ -1041,7 +1035,7 @@ eos_flexy_grid_get_cell_size (EosFlexyGrid *grid)
 {
   g_return_val_if_fail (EOS_IS_FLEXY_GRID (grid), 0);
 
-  EosFlexyGridPrivate *priv = grid->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (grid);
 
   if (priv->cell_size < 0)
     return DEFAULT_CELL_SIZE;
@@ -1064,7 +1058,7 @@ eos_flexy_grid_set_cell_spacing (EosFlexyGrid *grid,
 {
   g_return_if_fail (EOS_IS_FLEXY_GRID (grid));
 
-  EosFlexyGridPrivate *priv = grid->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (grid);
   if (priv->cell_spacing == spacing)
     return;
 
@@ -1086,7 +1080,7 @@ eos_flexy_grid_get_cell_spacing (EosFlexyGrid *grid)
 {
   g_return_val_if_fail (EOS_IS_FLEXY_GRID (grid), 0);
 
-  EosFlexyGridPrivate *priv = grid->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (grid);
 
   if (priv->cell_spacing < 0)
     return DEFAULT_SPACING;
@@ -1099,7 +1093,7 @@ do_grid_sort (gconstpointer row_a,
               gconstpointer row_b,
               gpointer data)
 {
-  EosFlexyGridPrivate *priv = EOS_FLEXY_GRID (data)->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (EOS_FLEXY_GRID (data));
 
   return priv->sort_func ((EosFlexyGridCell *) row_a,
                           (EosFlexyGridCell *) row_b,
@@ -1141,7 +1135,7 @@ eos_flexy_grid_insert (EosFlexyGrid *grid,
       gtk_widget_show (GTK_WIDGET (cell));
     }
 
-  EosFlexyGridPrivate *priv = grid->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (grid);
   GSequenceIter *iter;
 
   if (priv->sort_func != NULL)
@@ -1186,7 +1180,7 @@ eos_flexy_grid_get_cell_at_coords (EosFlexyGrid *grid,
 {
   g_return_val_if_fail (EOS_IS_FLEXY_GRID (grid), NULL);
 
-  EosFlexyGridPrivate *priv = grid->priv;
+  EosFlexyGridPrivate *priv = eos_flexy_grid_get_instance_private (grid);
   GSequenceIter *iter;
 
   /* naive hit detection */

--- a/endless/eosflexygrid.h
+++ b/endless/eosflexygrid.h
@@ -73,8 +73,6 @@ struct _EosFlexyGrid
 {
   /*< private >*/
   GtkContainer parent_instance;
-
-  gpointer priv;
 };
 
 struct _EosFlexyGridClass

--- a/endless/eosmainarea-private.h
+++ b/endless/eosmainarea-private.h
@@ -33,13 +33,10 @@ G_BEGIN_DECLS
 
 typedef struct _EosMainArea EosMainArea;
 typedef struct _EosMainAreaClass EosMainAreaClass;
-typedef struct _EosMainAreaPrivate EosMainAreaPrivate;
 
 struct _EosMainArea
 {
   GtkContainer parent;
-
-  EosMainAreaPrivate *priv;
 };
 
 struct _EosMainAreaClass

--- a/endless/eospagemanager.h
+++ b/endless/eospagemanager.h
@@ -37,7 +37,6 @@ G_BEGIN_DECLS
 
 typedef struct _EosPageManager EosPageManager;
 typedef struct _EosPageManagerClass EosPageManagerClass;
-typedef struct _EosPageManagerPrivate EosPageManagerPrivate;
 
 #define EOS_TYPE_PAGE_MANAGER_TRANSITION_TYPE (eos_page_manager_transition_type_get_type ())
 
@@ -70,8 +69,6 @@ typedef enum {
 struct _EosPageManager
 {
   GtkContainer parent;
-
-  EosPageManagerPrivate *priv;
 };
 
 struct _EosPageManagerClass

--- a/endless/eossplashpagemanager.h
+++ b/endless/eossplashpagemanager.h
@@ -39,7 +39,6 @@ G_BEGIN_DECLS
 
 typedef struct _EosSplashPageManager EosSplashPageManager;
 typedef struct _EosSplashPageManagerClass EosSplashPageManagerClass;
-typedef struct _EosSplashPageManagerPrivate EosSplashPageManagerPrivate;
 
 /**
  * EosSplashPageManager:
@@ -49,8 +48,6 @@ typedef struct _EosSplashPageManagerPrivate EosSplashPageManagerPrivate;
 struct _EosSplashPageManager
 {
   EosPageManager parent;
-
-  EosSplashPageManagerPrivate *priv;
 };
 
 struct _EosSplashPageManagerClass

--- a/endless/eostopbar-private.h
+++ b/endless/eostopbar-private.h
@@ -33,13 +33,10 @@ G_BEGIN_DECLS
 
 typedef struct _EosTopBar EosTopBar;
 typedef struct _EosTopBarClass EosTopBarClass;
-typedef struct _EosTopBarPrivate EosTopBarPrivate;
 
 struct _EosTopBar
 {
   GtkEventBox parent;
-
-  EosTopBarPrivate *priv;
 };
 
 struct _EosTopBarClass

--- a/endless/eostopbar.c
+++ b/endless/eostopbar.c
@@ -27,13 +27,7 @@
 #define _EOS_TOP_BAR_MINIMIZE_ICON_NAME "window-minimize-symbolic"
 #define _EOS_TOP_BAR_CLOSE_ICON_NAME "window-close-symbolic"
 
-G_DEFINE_TYPE (EosTopBar, eos_top_bar, GTK_TYPE_EVENT_BOX)
-
-#define TOP_BAR_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE ((o), EOS_TYPE_TOP_BAR, EosTopBarPrivate))
-
-struct _EosTopBarPrivate
-{
+typedef struct {
   GtkWidget *actions_grid;
   GtkWidget *left_top_bar_attach;
   GtkWidget *center_top_bar_attach;
@@ -45,7 +39,9 @@ struct _EosTopBarPrivate
   GtkWidget *minimize_icon;
   GtkWidget *close_button;
   GtkWidget *close_icon;
-};
+} EosTopBarPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE (EosTopBar, eos_top_bar, GTK_TYPE_EVENT_BOX)
 
 enum {
   CLOSE_CLICKED,
@@ -122,8 +118,6 @@ eos_top_bar_class_init (EosTopBarClass *klass)
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
 
-  g_type_class_add_private (klass, sizeof (EosTopBarPrivate));
-
   widget_class->button_press_event = eos_top_bar_button_press_event;
   widget_class->get_preferred_height = eos_top_bar_get_preferred_height;
   widget_class->draw = eos_top_bar_draw;
@@ -171,15 +165,14 @@ static void
 eos_top_bar_init (EosTopBar *self)
 {
   GtkStyleContext *context;
-
-  self->priv = TOP_BAR_PRIVATE (self);
+  EosTopBarPrivate *priv = eos_top_bar_get_instance_private (self);
 
   context = gtk_widget_get_style_context (GTK_WIDGET (self));
   gtk_style_context_add_class (context, _EOS_STYLE_CLASS_TOP_BAR);
 
   gtk_widget_set_hexpand (GTK_WIDGET (self), TRUE);
 
-  self->priv->actions_grid =
+  priv->actions_grid =
     g_object_new (GTK_TYPE_GRID,
                   "orientation", GTK_ORIENTATION_HORIZONTAL,
                   "hexpand", TRUE,
@@ -191,60 +184,60 @@ eos_top_bar_init (EosTopBar *self)
                   "margin-right", _EOS_TOP_BAR_HORIZONTAL_BUTTON_MARGIN_PX,
                   NULL);
 
-  self->priv->left_top_bar_attach = gtk_alignment_new (0.5, 0.5, 0.0, 0.0);
-  self->priv->center_top_bar_attach = gtk_alignment_new (0.5, 0.5, 0.0, 0.0);
-  gtk_widget_set_hexpand (self->priv->center_top_bar_attach, TRUE);
-  gtk_widget_set_halign (self->priv->center_top_bar_attach, GTK_ALIGN_CENTER);
+  priv->left_top_bar_attach = gtk_alignment_new (0.5, 0.5, 0.0, 0.0);
+  priv->center_top_bar_attach = gtk_alignment_new (0.5, 0.5, 0.0, 0.0);
+  gtk_widget_set_hexpand (priv->center_top_bar_attach, TRUE);
+  gtk_widget_set_halign (priv->center_top_bar_attach, GTK_ALIGN_CENTER);
 
   /* TODO implement adding actions and widgets to the actions_grid */
 
-  self->priv->minimize_button =
+  priv->minimize_button =
     g_object_new (GTK_TYPE_BUTTON,
                   "halign", GTK_ALIGN_END,
                   "valign", GTK_ALIGN_CENTER,
                   NULL);
-  self->priv->minimize_icon =
+  priv->minimize_icon =
     gtk_image_new_from_icon_name (_EOS_TOP_BAR_MINIMIZE_ICON_NAME,
                                   GTK_ICON_SIZE_SMALL_TOOLBAR);
-  g_object_set(self->priv->minimize_icon,
+  g_object_set(priv->minimize_icon,
                "pixel-size", _EOS_TOP_BAR_ICON_SIZE_PX,
                "margin", _EOS_TOP_BAR_BUTTON_PADDING_PX,
                NULL);
-  gtk_container_add (GTK_CONTAINER (self->priv->minimize_button),
-                     self->priv->minimize_icon);
+  gtk_container_add (GTK_CONTAINER (priv->minimize_button),
+                     priv->minimize_icon);
 
-  self->priv->close_button =
+  priv->close_button =
     g_object_new (GTK_TYPE_BUTTON,
                   "halign", GTK_ALIGN_END,
                   "valign", GTK_ALIGN_CENTER,
                   NULL);
-  self->priv->close_icon =
+  priv->close_icon =
       gtk_image_new_from_icon_name (_EOS_TOP_BAR_CLOSE_ICON_NAME,
                                     GTK_ICON_SIZE_SMALL_TOOLBAR);
-  g_object_set(self->priv->close_icon,
+  g_object_set(priv->close_icon,
                "pixel-size", _EOS_TOP_BAR_ICON_SIZE_PX,
                "margin", _EOS_TOP_BAR_BUTTON_PADDING_PX,
                NULL);
-  gtk_container_add (GTK_CONTAINER (self->priv->close_button),
-                     self->priv->close_icon);
+  gtk_container_add (GTK_CONTAINER (priv->close_button),
+                     priv->close_icon);
 
-  gtk_container_add (GTK_CONTAINER (self->priv->actions_grid),
-                     self->priv->left_top_bar_attach);
-  gtk_container_add (GTK_CONTAINER (self->priv->actions_grid),
-                     self->priv->center_top_bar_attach);
-  gtk_container_add (GTK_CONTAINER (self->priv->actions_grid),
-                     self->priv->minimize_button);
-  gtk_container_add (GTK_CONTAINER (self->priv->actions_grid),
-                     self->priv->close_button);
+  gtk_container_add (GTK_CONTAINER (priv->actions_grid),
+                     priv->left_top_bar_attach);
+  gtk_container_add (GTK_CONTAINER (priv->actions_grid),
+                     priv->center_top_bar_attach);
+  gtk_container_add (GTK_CONTAINER (priv->actions_grid),
+                     priv->minimize_button);
+  gtk_container_add (GTK_CONTAINER (priv->actions_grid),
+                     priv->close_button);
 
-  gtk_container_add (GTK_CONTAINER (self), self->priv->actions_grid);
+  gtk_container_add (GTK_CONTAINER (self), priv->actions_grid);
 
   gtk_widget_set_hexpand (GTK_WIDGET (self), TRUE);
   gtk_widget_set_halign (GTK_WIDGET (self), GTK_ALIGN_FILL);
 
-  g_signal_connect (self->priv->minimize_button, "clicked",
+  g_signal_connect (priv->minimize_button, "clicked",
                     G_CALLBACK (on_minimize_clicked_cb), self);
-  g_signal_connect (self->priv->close_button, "clicked",
+  g_signal_connect (priv->close_button, "clicked",
                     G_CALLBACK (on_close_clicked_cb), self);
 }
 
@@ -268,7 +261,7 @@ eos_top_bar_set_left_widget (EosTopBar *self,
   g_return_if_fail (EOS_IS_TOP_BAR (self));
   g_return_if_fail (left_top_bar_widget == NULL || GTK_IS_WIDGET (left_top_bar_widget));
 
-  EosTopBarPrivate *priv = self->priv;
+  EosTopBarPrivate *priv = eos_top_bar_get_instance_private (self);
 
   if (priv->left_top_bar_widget == left_top_bar_widget)
     return;
@@ -299,7 +292,7 @@ eos_top_bar_set_center_widget (EosTopBar *self,
   g_return_if_fail (EOS_IS_TOP_BAR (self));
   g_return_if_fail (center_top_bar_widget == NULL || GTK_IS_WIDGET (center_top_bar_widget));
 
-  EosTopBarPrivate *priv = self->priv;
+  EosTopBarPrivate *priv = eos_top_bar_get_instance_private (self);
 
   if (priv->center_top_bar_widget == center_top_bar_widget)
     return;

--- a/endless/eoswindow.h
+++ b/endless/eoswindow.h
@@ -38,7 +38,6 @@ G_BEGIN_DECLS
 
 typedef struct _EosWindow EosWindow;
 typedef struct _EosWindowClass EosWindowClass;
-typedef struct _EosWindowPrivate EosWindowPrivate;
 
 /**
  * EosWindow:
@@ -49,8 +48,6 @@ struct _EosWindow
 {
   /*< private >*/
   GtkApplicationWindow parent;
-
-  EosWindowPrivate *priv;
 };
 
 struct _EosWindowClass

--- a/test/test-action-menu.c
+++ b/test/test-action-menu.c
@@ -57,7 +57,8 @@ test_am_add_action (ActionMenuFixture *fixture,
 
   eos_action_menu_add_action (fixture->action_menu, fixture->action1);
 
-  GtkWidget *button = gtk_grid_get_child_at (GTK_GRID (fixture->action_menu->priv->center_grid), 0, 0);
+  EosActionMenuPrivate *action_menu_priv = eos_action_menu_get_instance_private (fixture->action_menu);
+  GtkWidget *button = gtk_grid_get_child_at (GTK_GRID (action_menu_priv->center_grid), 0, 0);
 
   g_assert (EOS_IS_ACTION_BUTTON (button));
 
@@ -111,10 +112,11 @@ menu_contains_button_with_label (EosActionMenu *menu, const gchar* button_label)
   GList* children;
   gboolean found = FALSE;
 
-  children = gtk_container_get_children (GTK_CONTAINER (menu->priv->center_grid));
+  EosActionMenuPrivate *action_menu_priv = eos_action_menu_get_instance_private (menu);
+  children = gtk_container_get_children (GTK_CONTAINER (action_menu_priv->center_grid));
 
   children = g_list_concat (children,
-                            gtk_container_get_children (GTK_CONTAINER (menu->priv->bottom_grid)));
+                            gtk_container_get_children (GTK_CONTAINER (action_menu_priv->bottom_grid)));
 
   for (GList *i = children; i != NULL ; i = i->next)
     {
@@ -170,8 +172,9 @@ test_am_remove_action (ActionMenuFixture *fixture,
   g_assert (g_list_find (list, fixture->action3) == NULL);
 
   // the container is empty
-  g_assert (gtk_container_get_children (GTK_CONTAINER (fixture->action_menu->priv->center_grid)) == NULL);
-  g_assert (gtk_container_get_children (GTK_CONTAINER (fixture->action_menu->priv->bottom_grid)) == NULL);
+  EosActionMenuPrivate *action_menu_priv = eos_action_menu_get_instance_private (fixture->action_menu);
+  g_assert (gtk_container_get_children (GTK_CONTAINER (action_menu_priv->center_grid)) == NULL);
+  g_assert (gtk_container_get_children (GTK_CONTAINER (action_menu_priv->bottom_grid)) == NULL);
 }
 
 static void


### PR DESCRIPTION
Simpler and has a nicer memory layout. Needed glib 2.38 to do this.
[endlessm/eos-sdk#421]
