### PR TITLE
Use System.exit() and System.programInvocationName

### DIFF
--- a/tools/eos-application-manifest/eos-application-manifest.in
+++ b/tools/eos-application-manifest/eos-application-manifest.in
@@ -5,8 +5,6 @@ const Format = imports.format;
 const System = imports.system;
 
 String.prototype.format = Format.format;
-// monkeypatch System.programInvocationName which is not in this version of GJS
-System.programInvocationName = 'eos-application-manifest';
 
 // Other constants, available from subcommands' code
 const commandSearchPath = "@datadir@/eos-application-manifest/commands";
@@ -21,8 +19,7 @@ if (ARGV.length === 0) {
     // automatically invoke "help" command with no arguments
     const Help = imports.help;
     Help.execute([]);
-    // System.exit(1); broken, bugzilla.gnome.org #703826
-    throw new Error();
+    System.exit(1);
 }
 
 let command_name = ARGV.shift();
@@ -34,14 +31,12 @@ try {
         let program_name = System.programInvocationName;
         printerr("%s: '%s' is not a valid command name. See %s help.".format(
             program_name, command_name, program_name));
-        // System.exit(1); broken
-        throw new Error();
+        System.exit(1);
     }
 }
 try {
     command.execute(ARGV);
 } catch (e) {
     printerr('%s: %s'.format(System.programInvocationName, e.message));
-    // System.exit(1); broken
-    throw e;
+    System.exit(1);
 }

--- a/tools/eos-run-test.in
+++ b/tools/eos-run-test.in
@@ -7,9 +7,6 @@ const Lang = imports.lang;
 const System = imports.system;
 
 String.prototype.format = Format.format;
-// Monkeypatch System.programInvocationName if not in this version of GJS
-if(!('programInvocationName' in System))
-    System.programInvocationName = 'eos-run-test';
 
 const PACKAGE_VERSION = '@PACKAGE_VERSION@';
 const JS_EXTENSION = '.js';
@@ -26,7 +23,7 @@ function usage() {
     print('Options:');
     print('  --help     This help message');
     print('  --version  Print version and exit');
-    throw(0); // FIXME System.exit(0);
+    System.exit(0);
 }
 
 /**
@@ -35,9 +32,9 @@ function usage() {
  * Print command-line version output.
  */
 function version() {
-    print('%s %s - Discover unit tests in a source tree'.format(
+    print('%s %s - Run jsUnit tests in a GJS source file'.format(
         System.programInvocationName, PACKAGE_VERSION));
-    throw(0); // FIXME System.exit(0);
+    System.exit(0);
 }
 
 if(ARGV.indexOf('--help') != -1)
@@ -146,5 +143,5 @@ print(totalsString);
 
 if (totals.testsFailedCount > 0){
     printerr("Test(s) did not complete successfully");
-    throw(1); // FIXME System.exit(1);
+    System.exit(1);
 }


### PR DESCRIPTION
In GJS >= 1.38, these facilities are available. This removes the
workarounds that we had for lack of these facilities.

[endlessm/eos-sdk#432]
