### PR TITLE
Set wiki background window to be black

### DIFF
--- a/data/css/eos-wikipedia-domain.css
+++ b/data/css/eos-wikipedia-domain.css
@@ -2,6 +2,10 @@
     font-family: Lato;
 }
 
+EosWindow {
+    background-color: black;
+}
+
 .title {
     font-family: "Lato Light";
     color: #ffffff;


### PR DESCRIPTION
Changes the color of the gaps between categories to black, to
match the specs
[endlessm/eos-sdk#446]
