### PR TITLE
Fix invalid free on gchar pointer

### DIFF
--- a/endless/eoswindow.c
+++ b/endless/eoswindow.c
@@ -274,7 +274,7 @@ format_background_css (EosPageManager *pm,
   // transparent. So any css styling of EosWindow will "show through" the
   // pages.
   if (background_uri == NULL)
-    return TRANSPARENT_FRAME_CSS_PROPERTIES;
+    return g_strdup (TRANSPARENT_FRAME_CSS_PROPERTIES);
   return g_strdup_printf (BACKGROUND_FRAME_CSS_PROPERTIES_TEMPLATE,
                           background_uri,
                           background_size,


### PR DESCRIPTION
The priv->current_background_css_props variable is sometimes assigned to a const gchar. Changing the const gchar to a malloc'd gchar pointer allows the existing g_free to free priv->current_background_css_props normally without checking for const values.

[endlessm/eos-sdk#478]
