### PR TITLE
Fixed ordering of type checking in public C methods

### DIFF
--- a/endless/eospagemanager.c
+++ b/endless/eospagemanager.c
@@ -1073,11 +1073,11 @@ eos_page_manager_set_page_name (EosPageManager *self,
                                 GtkWidget      *page,
                                 const gchar    *name)
 {
-  EosPageManagerPrivate *priv = eos_page_manager_get_instance_private (self);
-  EosPageManagerPageInfo *info;
-
   g_return_if_fail (EOS_IS_PAGE_MANAGER (self));
   g_return_if_fail (GTK_IS_WIDGET (page));
+
+  EosPageManagerPrivate *priv = eos_page_manager_get_instance_private (self);
+  EosPageManagerPageInfo *info;
 
   /* Two pages with the same name are not allowed */
   if (name != NULL)

--- a/endless/eoswindow.c
+++ b/endless/eoswindow.c
@@ -872,10 +872,10 @@ void
 eos_window_set_page_manager (EosWindow *self,
                              EosPageManager *page_manager)
 {
-  EosWindowPrivate *priv = eos_window_get_instance_private (self);
   g_return_if_fail (self != NULL && EOS_IS_WINDOW (self));
   g_return_if_fail (page_manager != NULL && EOS_IS_PAGE_MANAGER (page_manager));
 
+  EosWindowPrivate *priv = eos_window_get_instance_private (self);
   EosMainArea *main_area = EOS_MAIN_AREA (priv->main_area);
 
   priv->page_manager = page_manager;


### PR DESCRIPTION
In a couple of places, we would first access the private data of
and pointer, and then assert it was the type we were expecting
[endlessm/eos-sdk#469]
