### PR TITLE
Added a maximize button to eos-topbar

### DIFF
--- a/endless/eostopbar.c
+++ b/endless/eostopbar.c
@@ -143,7 +143,7 @@ on_minimize_clicked_cb (GtkButton *button,
 
 static void
 on_maximize_clicked_cb (GtkButton *button,
-                        gpointer user_data)
+                        gpointer   user_data)
 {
   EosTopBar *self = EOS_TOP_BAR (user_data);
   g_signal_emit (self, top_bar_signals[MAXIMIZE_CLICKED], 0);

--- a/endless/eoswindow.c
+++ b/endless/eoswindow.c
@@ -703,19 +703,16 @@ eos_window_class_init (EosWindowClass *klass)
 }
 
 static void
-on_minimize_clicked_cb (GtkWidget* top_bar,
-                        gpointer   data)
+on_minimize_clicked_cb (GtkWidget *top_bar,
+                        EosWindow *self)
 {
-  EosWindow *self = (EosWindow *)data;
-
   gtk_window_iconify (GTK_WINDOW (self));
 }
 
 static void
-on_maximize_clicked_cb (GtkWidget* top_bar,
-                        gpointer   data)
+on_maximize_clicked_cb (GtkWidget *top_bar,
+                        EosWindow *self)
 {
-  EosWindow *self = (EosWindow *)data;
   EosWindowPrivate *priv = eos_window_get_instance_private (self);
 
   if (priv->maximized)
@@ -725,21 +722,19 @@ on_maximize_clicked_cb (GtkWidget* top_bar,
 }
 
 static void
-on_close_clicked_cb (GtkWidget* top_bar,
-                     gpointer   data)
+on_close_clicked_cb (GtkWidget *top_bar,
+                     EosWindow *self)
 {
-  EosWindow *self = (EosWindow *)data;
-
   gtk_window_close (GTK_WINDOW (self));
 }
 
 static void
-on_window_state_event_cb (GtkWidget* widget,
-                          GdkEvent*  event)
+on_window_state_event_cb (GtkWidget           *widget,
+                          GdkEventWindowState *event)
 {
   EosWindow *self = EOS_WINDOW (widget);
   EosWindowPrivate *priv = eos_window_get_instance_private (self);
-  GdkWindowState window_state = ((GdkEventWindowState *)event)->new_window_state;
+  GdkWindowState window_state = event->new_window_state;
   priv->maximized = window_state & GDK_WINDOW_STATE_MAXIMIZED;
 }
 


### PR DESCRIPTION
Which toggles the application between a maximized and unmaximized
state. All applications will still start maximized by default.
[endlessm/eos-sdk#477]
