### PR TITLE
Override valign for AssetButton internals, not AssetButton

### DIFF
--- a/overrides/endless_private/asset_button.js
+++ b/overrides/endless_private/asset_button.js
@@ -46,7 +46,7 @@ const AssetButton = new Lang.Class({
         this.parent(params);
 
         this.set_image(this._image);
-        this._force_center_valign(this);
+        this.forall(Lang.bind(this, this._force_center_valign));
         this.connect('state-flags-changed', Lang.bind(this, this._update_appearance));
     },
 


### PR DESCRIPTION
Fixes the aligment of the disclaimer button in eos-wikipedia

[endlessm/eos-sdk#490]
