### PR TITLE
Fixed hit box of the category back button for wiki apps

### DIFF
--- a/data/css/eos-wikipedia-domain.css
+++ b/data/css/eos-wikipedia-domain.css
@@ -98,6 +98,11 @@ Gjs_CategoryButton.clickable:hover {
     color: alpha(white, 1.0);
 }
 
+#category-back-button {
+    padding-left: 40px;
+    padding-right: 40px;
+}
+
 Gjs_BackButton {
     -GtkButton-image-spacing: 7;
     padding-top: 2px;

--- a/wikipedia/PrebuiltCategoryPage.js
+++ b/wikipedia/PrebuiltCategoryPage.js
@@ -120,13 +120,14 @@ const PrebuiltCategoryPage = new Lang.Class({
             Gtk.PolicyType.AUTOMATIC);
 
         this._back_button = new Endless.AssetButton({
+            name: "category-back-button",
+            expand: true,
+            halign: Gtk.Align.START,
             valign: Gtk.Align.CENTER,
             normal_image_uri: "resource://com/endlessm/wikipedia-domain/assets/introduction_back_button_normal.png",
             active_image_uri: "resource://com/endlessm/wikipedia-domain/assets/introduction_back_button_pressed.png",
             prelight_image_uri: "resource://com/endlessm/wikipedia-domain/assets/introduction_back_button_hover.png",
-            label: _("OTHER CATEGORIES"),
-            margin_right: 10,
-            margin_left: 40
+            label: _("OTHER CATEGORIES")
         });
 
         this._back_button.connect('clicked', Lang.bind(this, function() {


### PR DESCRIPTION
It did not extend vertically or all the way to the left of the screen
[endlessm/eos-sdk#458]
