### PR TITLE
Fix position of "other categories" button

### DIFF
--- a/data/css/eos-wikipedia-domain.css
+++ b/data/css/eos-wikipedia-domain.css
@@ -130,8 +130,10 @@ Gjs_CategoryButton.clickable .image:hover {
 }
 
 .category-page .back {
-    padding-left: 25px;
-    padding-right: 25px;
+    /* button image should be 60px from the right. image needs 15 px padding for
+     * background glow, so we pad by 45 here */
+    padding-left: 45px;
+    padding-right: 45px;
 }
 
 Gjs_BackButton {


### PR DESCRIPTION
Design specified this should be 1/32 of the screen width away from
the left hand side. We don't have a great way to set percentage
margins, so just did this at 1080x1920 for now. So 1920/32=60 pixels
from the left
[endlessm/eos-sdk#519]
