### PR TITLE
Issues/535

### DIFF
--- a/endless/eospagemanager.c
+++ b/endless/eospagemanager.c
@@ -915,6 +915,7 @@ eos_page_manager_init (EosPageManager *self)
   gtk_widget_set_has_window (self_widget, FALSE);
 
   priv->stack = gtk_stack_new ();
+  gtk_widget_show (priv->stack);
   gtk_widget_set_parent (priv->stack, self_widget);
 }
 

--- a/endless/eoswindow.c
+++ b/endless/eoswindow.c
@@ -877,6 +877,8 @@ eos_window_init (EosWindow *self)
 
   eos_window_set_page_manager (self,
                                EOS_PAGE_MANAGER (eos_page_manager_new ()));
+  // Make our internal widgets visible, so user needs only call show on the window.
+  gtk_widget_show_all (priv->overlay);
 }
 
 /* Public API */

--- a/test/endless/test-window.c
+++ b/test/endless/test-window.c
@@ -226,6 +226,25 @@ test_main_area_widgets_visibility (GApplication *app)
   gtk_widget_destroy (win);
 }
 
+static void
+test_internal_widget_visibility (GApplication *app) {
+  GtkWidget *win = eos_window_new (EOS_APPLICATION (app));
+  EosPageManager *pm = eos_window_get_page_manager (EOS_WINDOW (win));
+  GtkWidget *page0 = gtk_label_new ("test");
+
+  gtk_container_add (GTK_CONTAINER (pm), page0);
+  gtk_widget_show (page0);
+  gtk_widget_show (win);
+
+  // We have a lot of internal widgets, if we forgotten to call show on one of
+  // them the label won't be visible, even though we just called show on the
+  // two widgets we created in this test.
+  g_assert (gtk_widget_is_visible (page0));
+
+  gtk_widget_destroy (win);
+}
+
+
 void
 add_window_tests (void)
 {
@@ -249,4 +268,6 @@ add_window_tests (void)
   ADD_APP_WINDOW_TEST ("/window/prop-page-manager", test_prop_page_manager);
   ADD_APP_WINDOW_TEST ("/window/main-area-widgets-visibility",
                        test_main_area_widgets_visibility);
+  ADD_APP_WINDOW_TEST ("/window/internal-widget-visibility",
+                       test_internal_widget_visibility);
 }


### PR DESCRIPTION
First commit fixes the problem stated in the issue description. But then realized that we should be calling show on all our internals, we shouldn't require an sdk user to call show_all on the top level.

Second commit fixes that issue and makes sure show is called on all internals. Makes the first commit redundant, but prefer to keep that in, in case we change how we manager our show calls someday. 

Added a visibility test make sure we showing what we should be.
#535
