### PR TITLE
flexygrid: Deselect cell when on empty space

### DIFF
--- a/endless/eosflexygrid.c
+++ b/endless/eosflexygrid.c
@@ -653,8 +653,7 @@ eos_flexy_grid_motion_notify (GtkWidget *widget,
     }
 
   EosFlexyGridCell *cell = eos_flexy_grid_get_cell_at_coords (self, relative_x, relative_y);
-  if (cell != NULL)
-    eos_flexy_grid_update_cell_prelight (self, cell);
+  eos_flexy_grid_update_cell_prelight (self, cell);
 
   return GDK_EVENT_PROPAGATE;
 }


### PR DESCRIPTION
The pointer may be on empty space while still within the bounds of the
FlexyGrid widget.

[endlessm/eos-shell#1887]
