### PR TITLE
Don't try to open browser-*:// URI schemes locally

### DIFF
--- a/wikipedia/WikipediaWebView.js
+++ b/wikipedia/WikipediaWebView.js
@@ -137,13 +137,14 @@ const WikipediaWebView = new Lang.Class({
                 let suffix = parts[parts.length - 1];
                 let id = decodeURI(suffix);
                 this.loadArticleById(id);
-                return true;
+                decision.ignore();
+                return true; // handled
             } else if (GLib.uri_parse_scheme(uri).startsWith('browser-')) {
                 // Open everything that starts with 'browser-' in the system
                 // browser
                 let realURI = uri.slice('browser-'.length);
-                printerr('Showing', realURI);
                 Gtk.show_uri(null, realURI, Gdk.CURRENT_TIME);
+                decision.ignore();
                 return true; // handled
             }
         }


### PR DESCRIPTION
Previously, browser-http:// URIs would open as http:// URIs in the
system browser, but the in-app webview would also try to display them
(and fail). This makes sure that the in-app webview ignores the URI
after passing it on to the system browser.

[endlessm/eos-wikipedia-offline#304]
