### PR TITLE
Rounded corners on unmaximized top bar

### DIFF
--- a/data/css/endless-widgets.css
+++ b/data/css/endless-widgets.css
@@ -37,6 +37,10 @@ EosWindow {
         from(#464646), to(#1e1e1e));
 }
 
+.top-bar.unmaximized {
+    border-radius: 7px 7px 0px 0px;
+}
+
 .top-bar:backdrop {
     background-image: -gtk-gradient(linear, center top, center bottom,
         from(#282828), to(#1e1e1e));

--- a/endless/eostopbar.c
+++ b/endless/eostopbar.c
@@ -18,6 +18,7 @@
  * The action buttons area contain "minimize", "maximize" and "close" buttons.
  */
 #define _EOS_STYLE_CLASS_TOP_BAR "top-bar"
+#define _EOS_STYLE_CLASS_UNMAXIMIZED "unmaximized"
 #define _EOS_TOP_BAR_HEIGHT_PX 36
 #define _EOS_TOP_BAR_BUTTON_PADDING_PX 4
 #define _EOS_TOP_BAR_ICON_SIZE_PX 16
@@ -344,4 +345,10 @@ eos_top_bar_update_window_maximized (EosTopBar *self,
   gtk_image_set_from_icon_name (GTK_IMAGE (priv->maximize_icon),
                                 icon_name,
                                 GTK_ICON_SIZE_SMALL_TOOLBAR);
+
+  GtkStyleContext *context = gtk_widget_get_style_context (GTK_WIDGET (self));
+  if (!is_maximized)
+    gtk_style_context_add_class (context, _EOS_STYLE_CLASS_UNMAXIMIZED);
+  else
+    gtk_style_context_remove_class (context, _EOS_STYLE_CLASS_UNMAXIMIZED);
 }


### PR DESCRIPTION
The window manager already does this for most programs. But we have
to do it ourselves in the SDK as we have self decorated windows
[endlessm/eos-sdk#551]
