### PR TITLE
Remove manual garbage collection

### DIFF
--- a/wikipedia/views/domain_wiki_view.js
+++ b/wikipedia/views/domain_wiki_view.js
@@ -1,6 +1,5 @@
 const EndlessWikipedia = imports.wikipedia.EndlessWikipedia;
 const Lang = imports.lang;
-const System = imports.system;
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Gdk = imports.gi.Gdk;
@@ -57,16 +56,6 @@ const DomainWikiView = new Lang.Class({
         })
      
         this._window.show_all();
-
-        // A temporary measure to prevent memory usage from blowing up. The app
-        // will sometimes allocate pixbufs as part of its draw function and gjs
-        // will not cleanup unused pixbufs unless we force it to.
-        this._window.connect_after("draw", function () {
-            Gdk.threads_add_idle(GLib.PRIORITY_LOW, function () {
-                System.gc();
-                return false;
-            });
-        });
     },
 
     create_front_page: function(){


### PR DESCRIPTION
It's not necessary anymore if we patch GJS so that the garbage
collection runs at reasonable intervals.

[endlessm/eos-shell#2026]
