### PR TITLE
Added category_back_button to POTFILES

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,3 @@
 # List of source files which contain translatable strings.
-wikipedia/views/domain_wiki_view.js
 wikipedia/widgets/BackButton.js
-wikipedia/PrebuiltCategoryPage.js
+wikipedia/widgets/category_back_button.js


### PR DESCRIPTION
The string we want to translate got moved to another file some time
ago, and we were relying on a version controlled .pot file until
the automated Jenkins/TX job "corrected" things

[endlessm/eos-sdk#695]
