### PR TITLE
Removed "jhbuild update" from ansible playbooks

### DIFF
--- a/ansible/playbooks/jhbuild_run.yaml
+++ b/ansible/playbooks/jhbuild_run.yaml
@@ -14,6 +14,3 @@
 
     - name: "Installing auth key"
       template: src=../templates/.jhbuildrc-auth.j2 dest=~/.jhbuildrc-auth
-
-    - name: "Cloning relevant modules - this will take a very long time - use htop and watch for git processes"
-      shell: executable=/bin/bash ~/.local/bin/jhbuild update endless-apps


### PR DESCRIPTION
Given that `jhbuild update endless-apps` takes a long time and it may break on unstable connections, it is better to remove it from the ansible script and leave it to the user to run in the guest machine.
