### PR TITLE
Install overrides in gir package not in binary package

### DIFF
--- a/debian/eos-sdk.install
+++ b/debian/eos-sdk.install
@@ -1,3 +1,2 @@
 usr/lib/libendless-0.so.*
 usr/share/locale/*
-usr/share/gjs-1.0/overrides/*

--- a/debian/gir1.2-endless-0.install
+++ b/debian/gir1.2-endless-0.install
@@ -1,1 +1,2 @@
 usr/lib/girepository-1.0/Endless*.typelib
+usr/share/gjs-1.0/overrides/*


### PR DESCRIPTION
Doesn't make sense to give gjs overrides in the binary package
which doesn't have the .typelib file needed for the override to
even work
