### PR TITLE
Fix testsuite

### DIFF
--- a/docs/reference/endless/.gitignore
+++ b/docs/reference/endless/.gitignore
@@ -17,3 +17,4 @@
 /version.xml
 /xml
 /*.bak
+/gtkdoc-check.test

--- a/docs/reference/endless/Makefile.am
+++ b/docs/reference/endless/Makefile.am
@@ -93,8 +93,5 @@ TESTS_ENVIRONMENT = \
 	export DOC_MAIN_SGML_FILE=$(DOC_MAIN_SGML_FILE); \
 	export SRCDIR=$(abs_srcdir); \
 	export BUILDDIR=$(abs_builddir);
-# Need a dummy file to feed to GTKDOC_CHECK in the parallel test harness
-TESTS = gtkdoc-test-dummy-file
-LOG_COMPILER = $(GTKDOC_CHECK)
-EXTRA_DIST += gtkdoc-test-dummy-file
+TESTS = $(GTKDOC_CHECK)
 endif


### PR DESCRIPTION
Two problems.
1. AM_TESTS_ENVIRONMENT isn't supported on endless' automake-1.11.6, which meant that DOC_MODULE wasn't actually being passed to the test.
2. Updated gtk-doc has its own workaround for parallel tests on automake meaning that GTKDOC_CHECK should be set directly in TESTS.

[endlessm/eos-sdk#953]
