### PR TITLE
Endless gjs runner

### DIFF
--- a/tools/Makefile.am.inc
+++ b/tools/Makefile.am.inc
@@ -4,6 +4,7 @@ bin_SCRIPTS = \
 	tools/eos-run-test \
 	tools/eos-application-manifest/eos-application-manifest \
 	tools/eos-json-extractor/eos-json-extractor \
+	tools/ejs \
 	$(NULL)
 
 # Use the following script to replace $datadir inside the script, as suggested

--- a/tools/ejs
+++ b/tools/ejs
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+JS_DIR=eos-js-common
+
+# As defined in http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+if [[ -z "$XDG_DATA_DIRS" ]]; then
+    XDG_DATA_DIRS="/usr/local/share/:/usr/share/"
+fi
+
+# Add JS_DIR to the gjs path in each XDG_DATA_DIR
+for DATA_DIR in ${XDG_DATA_DIRS//:/ }; do
+    GJS_PATH=${GJS_PATH}:${DATA_DIR}/${JS_DIR}
+done
+
+# Strip leading ":" if present and export
+export GJS_PATH=${GJS_PATH#:}
+gjs $@


### PR DESCRIPTION
Adds a eos-js-common directory to the gjs path so we have a common
place to put endless javascript libraries
[endlessm/eos-sdk#1026]
