### PR TITLE
Remove locale install paths since all po files removed

### DIFF
--- a/debian/eos-sdk.install
+++ b/debian/eos-sdk.install
@@ -1,2 +1,1 @@
 usr/lib/libendless-0.so.*
-usr/share/locale/*


### PR DESCRIPTION
Commit e4d39a3 removed the po files, but did not remove the install
paths from the debian packaging.

[endlessm/eos-sdk#1251]
