### PR TITLE
Make topbar buttons no longer focusable

### DIFF
--- a/endless/eostopbar.c
+++ b/endless/eostopbar.c
@@ -191,6 +191,7 @@ eos_top_bar_init (EosTopBar *self)
 
   priv->minimize_button =
     g_object_new (GTK_TYPE_BUTTON,
+                  "can-focus", FALSE,
                   "halign", GTK_ALIGN_END,
                   "valign", GTK_ALIGN_CENTER,
                   NULL);
@@ -206,6 +207,7 @@ eos_top_bar_init (EosTopBar *self)
 
   priv->maximize_button =
     g_object_new (GTK_TYPE_BUTTON,
+                  "can-focus", FALSE,
                   "halign", GTK_ALIGN_END,
                   "valign", GTK_ALIGN_CENTER,
                   NULL);
@@ -220,6 +222,7 @@ eos_top_bar_init (EosTopBar *self)
 
   priv->close_button =
     g_object_new (GTK_TYPE_BUTTON,
+                  "can-focus", FALSE,
                   "halign", GTK_ALIGN_END,
                   "valign", GTK_ALIGN_CENTER,
                   NULL);


### PR DESCRIPTION
Set 'can-focus' properties to false for the buttons on the topbar
of the window (minimize, maximize, close). This was in response to
a bug in which the focus was being stolen by the maximize button
after clicking it and the eos-typing app was unable to regain,
now the behavior is consistent with all non-Endless applications.
[endlessm/eos-sdk#1043]
