### PR TITLE
Fix size request clamping for height_for_width width_for_height

### DIFF
--- a/endless/eoswindow.c
+++ b/endless/eoswindow.c
@@ -457,12 +457,9 @@ eos_window_finalize (GObject *object)
 /* Clamp our size request calls so we never ask for a minimal size greater than
  the available work area. */
 static void
-clamp_size_request (GtkWidget      *widget,
-                    GtkOrientation  orientation,
-                    gint            *minimum_size,
-                    gint            *natural_size)
+clamp_allocation (GtkWidget     *widget,
+                  GtkAllocation *allocation)
 {
-
   if (gtk_widget_get_realized (widget))
     {
       GdkScreen *default_screen = gdk_screen_get_default ();
@@ -470,57 +467,19 @@ clamp_size_request (GtkWidget      *widget,
       int monitor = gdk_screen_get_monitor_at_window (default_screen, gdkwindow);
       GdkRectangle workarea;
       gdk_screen_get_monitor_workarea (default_screen, monitor, &workarea);
-      gint available_size = workarea.width;
-      gchar *orientation_string = "width";
-      if (orientation == GTK_ORIENTATION_VERTICAL)
-        {
-          available_size = workarea.height;
-          orientation_string = "height";
-        }
-
-      if (*minimum_size > available_size)
-        {
-          g_critical ("Requested window %s %d greater than available work area %s %d. " \
-                      "Clamping size request to fit. This means there is a bug in your " \
-                      "program, and it is not ready for production. Try checking if any " \
-                      "of your widgets have minimum size requests that make the page not " \
-                      "able to fit on the screen.",
-                      orientation_string,
-                      *minimum_size,
-                      orientation_string,
-                      available_size);
-          *minimum_size = available_size;
-          *natural_size = MAX (*minimum_size, *natural_size);
-        }
+      if (allocation->width > workarea.width) {
+        g_critical ("EosWindow receiving allocation %d greater than the available " \
+                    "workarea width %d. This probably means your minimal width request " \
+                    "is too big.", allocation->width, workarea.width);
+        allocation->width = workarea.width;
+      }
+      if (allocation->height > workarea.height) {
+        g_critical ("EosWindow receiving allocation %d greater than the available " \
+                    "workarea height %d. This probably means your minimal height request " \
+                    "is too big.", allocation->height, workarea.height);
+        allocation->height = workarea.height;
+      }
     }
-}
-
-static void
-eos_window_get_preferred_width (GtkWidget *widget,
-                                gint *minimum_width,
-                                gint *natural_width)
-{
-  GTK_WIDGET_CLASS (eos_window_parent_class)->get_preferred_width (widget,
-    minimum_width, natural_width);
-
-  clamp_size_request (widget,
-                      GTK_ORIENTATION_HORIZONTAL,
-                      minimum_width,
-                      natural_width);
-}
-
-static void
-eos_window_get_preferred_height (GtkWidget *widget,
-                                 gint *minimum_height,
-                                 gint *natural_height)
-{
-  GTK_WIDGET_CLASS (eos_window_parent_class)->get_preferred_height (widget,
-    minimum_height, natural_height);
-
-  clamp_size_request (widget,
-                      GTK_ORIENTATION_VERTICAL,
-                      minimum_height,
-                      natural_height);
 }
 
 /* Updates the base font size depending on the window size. */
@@ -529,6 +488,7 @@ eos_window_size_allocate (GtkWidget *window, GtkAllocation *allocation)
 {
   EosWindow *self = EOS_WINDOW (window);
   EosWindowPrivate *priv = eos_window_get_instance_private (self);
+  clamp_allocation(window, allocation);
 
   if (priv->font_scaling_active)
     {
@@ -582,8 +542,6 @@ eos_window_class_init (EosWindowClass *klass)
   object_class->get_property = eos_window_get_property;
   object_class->set_property = eos_window_set_property;
   object_class->finalize = eos_window_finalize;
-  widget_class->get_preferred_height = eos_window_get_preferred_height;
-  widget_class->get_preferred_width = eos_window_get_preferred_width;
   widget_class->size_allocate = eos_window_size_allocate;
 
   /**


### PR DESCRIPTION
Our size request clamping code would only work for size requests where width
and height would be handled independently, if height_for_width or
height_for_width is used the clamping would not work. Adapting the same
clamping isn't quite correct either, as its not wrong for a window to return
an overlarge height request when given a tiny width or vice versa

So instead just handle the clamping and the warning at the size allocation
level. This limits us from sizing windows greater than one monitors size in a
dual monitor setup. If we want that feature we can delete the clamp code,
though I'd prefer to keep it in for now, as our font scaling can blow up size
request without a limit like this
[endlessm/eos-sdk#1080]
