### PR TITLE
Implemented connection tests into overrides.

### DIFF
--- a/overrides/Endless.js
+++ b/overrides/Endless.js
@@ -24,12 +24,14 @@ function getCurrentFileDir() {
 imports.searchPath.unshift(getCurrentFileDir());
 
 const AssetButton = imports.endless_private.asset_button;
+const ConnectionTest = imports.endless_private.connection_test;
 
 function _init() {
     // this is imports.gi.Endless
     Endless = this;
     Endless.getCurrentFileDir = getCurrentFileDir;
     Endless.AssetButton = AssetButton.AssetButton;
+    Endless.doConnectionTestAsync = ConnectionTest.doConnectionTestAsync;
 
     // Override Endless.PageManager.add() so that you can set child properties
     // at the same time
@@ -41,5 +43,5 @@ function _init() {
                 this.child_set_property(child, prop_id, props[prop_id]);
             }
         }
-    }
+    };
 }

--- a/overrides/Makefile.am.inc
+++ b/overrides/Makefile.am.inc
@@ -6,6 +6,7 @@ gjsdir = ${datadir}/gjs-1.0
 
 # Put override files here for custom js API outside of normal introspection
 nobase_dist_gjs_DATA = \
-	overrides/Endless.js \
-	overrides/endless_private/asset_button.js \
-	$(NULL)
+    overrides/Endless.js \
+    overrides/endless_private/asset_button.js \
+    overrides/endless_private/connection_test.js \
+    $(NULL)

--- a/overrides/endless_private/connection_test.js
+++ b/overrides/endless_private/connection_test.js
@@ -1,0 +1,42 @@
+const Gio = imports.gi.Gio;
+
+// Performs a connection test by first looking for an available connection, and
+// performing a ping test with address parameters specified by hostname, scheme,
+// and port. The test is performed asynchronously.
+// successCallback, failureCallback, and errorCallback are optional parameters
+// and are called in their relevent outcome cases. If the ping test completed,
+// the userData will be passed to the callbacks. Additionally, the errorCallback
+// will recieve the error as the first argument.
+function doConnectionTestAsync(hostname, scheme, port, connectionSuccessCallback,
+                                                       connectionFailureCallback,
+                                                       errorCallback) {
+    let network_monitor = Gio.NetworkMonitor.get_default();
+    let network_address = new Gio.NetworkAddress({
+        'hostname': hostname,
+        'scheme': scheme,
+        'port': port
+    });
+
+    if (network_monitor.get_network_available()) {
+        network_monitor.can_reach_async(network_address, null,
+                                        function(userData, asyncResult) {
+            try {
+                let ping_success = network_monitor.
+                                   can_reach_finish(asyncResult, null);
+                if (ping_success && connectionSuccessCallback) {
+                    connectionSuccessCallback(userData);
+                } else if (!ping_success && connectionFailureCallback) {
+                    connectionFailureCallback(userData);
+                }
+            } catch (err) {
+                if (err instanceof Gio.ResolverError) {
+                    connectionFailureCallback(userData);
+                } else if (errorCallback) {
+                    errorCallback(err, userData);
+                }
+            }
+        });
+    } else if (connectionFailureCallback) {
+        connectionFailureCallback();
+    }
+}


### PR DESCRIPTION
The Endless api now includes an asynchronous method for testing network connectivity. This test works by ensuring that there is a network available, and pinging the specified host if so.

[endlessm/eos-sdk#1383]
