### PR TITLE
EntryCompletion matches all results in model

### DIFF
--- a/overrides/endless_private/search_box.js
+++ b/overrides/endless_private/search_box.js
@@ -53,6 +53,7 @@ const SearchBox = new Lang.Class({
         cells[0].xpad = CELL_PADDING_X;
         cells[0].ypad = CELL_PADDING_Y;
 
+        this._auto_complete.set_match_func(function () { return true; });
         this.completion = this._auto_complete;
 
         this.connect('icon-press', Lang.bind(this, function () {


### PR DESCRIPTION
Previously we were using the entry completions default
match function which will filter words by prefix. However
we want all filtering to be done in the knowledge engine
in a smarter way so this entry completion should just match
on all results.

https://github.com/endlessm/eos-sdk/issues/1651
