### PR TITLE
Copy system theme for context menu styling

### DIFF
--- a/data/css/endless-widgets.css
+++ b/data/css/endless-widgets.css
@@ -162,3 +162,38 @@ EosWindow {
 .scrollbar {
     -GtkScrollbar-min-slider-length: 28;
 }
+
+/*
+ * Themeing for context menus, to get Adwaita look
+ * FIXME: Really gross to be duplicating all this Adwaita theme here. If the
+ * :not selector is ever supported in gtk css, just :not(.context-menu) and
+ * children in reset.css and drop all of this.
+ */
+@define-color endless_menu_fg_color #2e3436;
+@define-color endless_menu_bg_color shade (#ededed, 1.1);
+
+.context-menu {
+    font: initial;
+    color: @endless_menu_fg_color;
+    background-color: @endless_menu_bg_color;
+}
+
+.context-menu .menuitem {
+    padding: 4px;
+    -GtkMenuItem-arrow-scaling: 0.4;
+}
+
+.context-menu .menuitem:active,
+.context-menu .menuitem:hover {
+    color: #ffffff;
+    background-color: #4a90d9;
+}
+
+.context-menu .menuitem *:insensitive {
+    color: mix (@endless_menu_fg_color, @endless_menu_bg_color, 0.6);
+}
+
+.context-menu .menuitem.separator {
+    color: mix (@endless_menu_fg_color, @endless_menu_bg_color, 0.9);
+    -GtkMenuItem-horizontal-padding: 0;
+}


### PR DESCRIPTION
The current styling just left text as white, background as black
with no styling for hover and insensitive states, which looked
terrible. We've decided to just use the system theme instead

Unfortunately because there's no support for the :not selector
in css, there's no easy way to exempt our context menus from the
theming reset. So just duplicated the system theme for our context
menus for now
[endlessm/eos-sdk#617]
