### PR TITLE
Change test in testWebActions

### DIFF
--- a/test/webhelper/testWebActions.js
+++ b/test/webhelper/testWebActions.js
@@ -48,7 +48,9 @@ describe("Web Actions Bindings", function() {
             application_id: id_string
         });
         webActionSpy = jasmine.createSpy('quitAction').and.callFake(function() {
-            app.quit();
+            // Calls destroy on the applications window, which decrements the hold count on the
+            // application and implicitly causes the application to close.
+            app.win.destroy();
         });
     });
     


### PR DESCRIPTION
When calling app.quit(), the hold count on the application is ignored,
which causes undefined behavior when the application's window still
thinks it has a hold on the application and control is returned
to the MainLoop. This patch changes the way that applications are
quit in testWebActions by calling destroy() on the application's window,
which decrements the hold count on the application and implicitly causes
the application to close.

[endlessm/eos-sdk#1881]
