### PR TITLE
Make our default height 570 pixels

### DIFF
--- a/endless/eoswindow.c
+++ b/endless/eoswindow.c
@@ -63,7 +63,7 @@
  */
 
 #define DEFAULT_WINDOW_WIDTH 800
-#define DEFAULT_WINDOW_HEIGHT 600
+#define DEFAULT_WINDOW_HEIGHT 570
 
 #define BACKGROUND_FRAME_NAME_TEMPLATE "_eos-window-background-%d"
 


### PR DESCRIPTION
600 pixels is bigger than our work area at our minimum resolution of
800x600 and it was giving us terminal warnings. The 30 pixels is
needed for the bottom bar to display properly
