### PR TITLE
TopbarNavButton works with no_show_all

### DIFF
--- a/overrides/endless_private/topbar_nav_button.js
+++ b/overrides/endless_private/topbar_nav_button.js
@@ -64,6 +64,8 @@ const TopbarNavButton = new Lang.Class({
 
         this.add(this._back_button);
         this.add(this._forward_button);
+        this._back_button.show();
+        this._forward_button.show();
     },
 
     get back_button() {

--- a/test/endless/Makefile.am.inc
+++ b/test/endless/Makefile.am.inc
@@ -16,4 +16,5 @@ test_endless_run_tests_LDADD = $(TEST_LIBS)
 
 javascript_tests += \
 	test/endless/testCustomContainer.js \
+	test/endless/testTopbarNavButton.js \
 	$(NULL)

--- a/test/endless/testTopbarNavButton.js
+++ b/test/endless/testTopbarNavButton.js
@@ -1,0 +1,17 @@
+const Endless = imports.gi.Endless;
+const Gtk = imports.gi.Gtk;
+const Lang = imports.lang;
+
+Gtk.init(null);
+
+describe('TopbarNavButton', function () {
+    it('works correctly with no_show_all', function () {
+        let button = new Endless.TopbarNavButton({
+            no_show_all: true,
+        });
+        button.show();
+        expect(button.visible).toBe(true);
+        expect(button.back_button.visible).toBe(true);
+        expect(button.forward_button.visible).toBe(true);
+    });
+});


### PR DESCRIPTION
Previously, if you created an Endless.TopbarNavButton with no_show_all
set to TRUE, and subsequently called show() on it, it would not become
visible, because the child widgets were still not shown. By showing them
at construct time, we solve this problem because they immediately become
visible when the TopbarNavButton widget itself is shown.

[endlessm/eos-sdk#2495]
