### PR TITLE
build: use AC_PROG_CC_C99

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,9 +125,7 @@ AC_SUBST(GLIB_COMPILE_RESOURCES)
 AC_CACHE_SAVE
 
 # Check that the compiler supports C99, and enable it in our CFLAGS
-AS_COMPILER_FLAGS(C99_CFLAGS, "-std=c99")
-C99_CFLAGS=${C99_CFLAGS#*  }
-CFLAGS="$CFLAGS $C99_CFLAGS"
+AC_PROG_CC_C99
 
 # Configure options
 # -----------------


### PR DESCRIPTION
Instead of our hand rolled check.

[endlessm/eos-sdk#2455]
