### PR TITLE
Install eos-coverage.m4 as part of eos-sdk-0-dev

### DIFF
--- a/debian/eos-sdk-0-dev.install
+++ b/debian/eos-sdk-0-dev.install
@@ -2,3 +2,4 @@ usr/include/endless*/*
 usr/lib/pkgconfig/endless*.pc
 usr/lib/libendless*.so
 usr/share/gir-1.0/Endless*.gir
+usr/share/aclocal/eos-*.m4


### PR DESCRIPTION
[endlessm/eos-shell#2264]
