### PR TITLE
Bump version epoch to 2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+eos-sdk (2:0.0.0) UNRELEASED; urgency=low
+
+  * Bump epoch to 2, because epoch 1 did not get the proper Version tags
+    and ended up 1:1.3.0. [endlessm/eos-sdk#2648].
+
+ -- Philip Chimento <philip@endlessm.com>  Fri, 16 Jan 2015 16:53:43 -0800
+
 eos-sdk (1:0.0.0) unstable; urgency=low
 
   * Start over at version 0.0.0 since we are doing API versioning now.


### PR DESCRIPTION
The version that was supposed to be 1:0.0.0 mistakenly became 1:1.3.0.
This increments the epoch so we can reset to 0.0.0 again.

[endlessm/eos-sdk#2648]
