### PR TITLE
Add debug package and required rules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -50,6 +50,14 @@ Conflicts: eos-sdk-dev
 Description: Endless SDK development package
  Development headers for the Endless SDK
 
+Package: eos-sdk-0-dbg
+Section: non-free/debug
+Architecture: any
+Depends: ${misc:Depends},
+         libendless-0-0 (= ${binary:Version})
+Description: Endless SDK debugging symbols
+ Debugging symbols for the Endless SDK
+
 Package: eos-sdk-0-doc
 Section: non-free/doc
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -20,3 +20,7 @@ override_dh_auto_configure:
 # this, but right now the tests fail because Gtk is initialized but can't find
 # an X window
 override_dh_auto_test:
+
+# Debug package setup. See https://wiki.debian.org/DebugPackage.
+override_dh_strip:
+	dh_strip --dbg-package=eos-sdk-0-dbg


### PR DESCRIPTION
Process copied from https://wiki.debian.org/DebugPackage for debhelper
packages.

[endlessm/eos-shell#4451]
