### PR TITLE
Deprecate EosFlexyGrid API

### DIFF
--- a/endless/eosflexygrid.c
+++ b/endless/eosflexygrid.c
@@ -8,10 +8,13 @@
  * The #EosFlexyGrid widget provides a grid of cells in a layout controlled
  * by the shape of the cells themselves, through the #EosFlexyGridCell:shape
  * property of #EosFlexyGridCell.
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 
 #include "config.h"
 
+#define EOS_SDK_DISABLE_DEPRECATION_WARNINGS
 #include "eosflexygrid-private.h"
 
 #include <string.h>
@@ -872,6 +875,8 @@ eos_flexy_grid_class_init (EosFlexyGridClass *klass)
    * EosFlexyGrid:cell-size:
    *
    * The minimum size of each cell inside a #EosFlexyGrid, or -1 for the default.
+   *
+   * Deprecated: 0.2: Use a #GtkGrid instead
    */
   grid_props[PROP_CELL_SIZE] =
     g_param_spec_int ("cell-size",
@@ -885,6 +890,8 @@ eos_flexy_grid_class_init (EosFlexyGridClass *klass)
    * EosFlexyGrid:cell-spacing:
    *
    * The spacing between each cell inside a #EosFlexyGrid, or -1 for the default.
+   *
+   * Deprecated: 0.2: Use a #GtkGrid instead
    */
   grid_props[PROP_CELL_SPACING] =
     g_param_spec_int ("cell-spacing",
@@ -903,6 +910,8 @@ eos_flexy_grid_class_init (EosFlexyGridClass *klass)
    *
    * The ::cell-selected signal is emitted each time a cell inside @grid
    * is selected. Selection happens by hovering on a cell.
+   *
+   * Deprecated: 0.2: Use a #GtkGrid instead
    */
   grid_signals[CELL_SELECTED] =
     g_signal_new (g_intern_static_string ("cell-selected"),
@@ -921,6 +930,8 @@ eos_flexy_grid_class_init (EosFlexyGridClass *klass)
    *
    * The ::cell-activated signal is emitted each time a cell inside @grid
    * is activated. Activation happens by clicking on a cell.
+   *
+   * Deprecated: 0.2: Use a #GtkGrid instead
    */
   grid_signals[CELL_ACTIVATED] =
     g_signal_new (g_intern_static_string ("cell-activated"),
@@ -958,6 +969,8 @@ eos_flexy_grid_init (EosFlexyGrid *self)
  * Creates a new #EosFlexyGrid widget.
  *
  * Return value: (transfer full): the newly created #EosFlexyGrid widget
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 GtkWidget *
 eos_flexy_grid_new (void)
@@ -984,6 +997,8 @@ eos_flexy_grid_new (void)
  * The @notify function will be called when this function is called
  * with a different @sort_func (or %NULL); or when the @grid widget
  * is destroyed.
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 void
 eos_flexy_grid_set_sort_func (EosFlexyGrid         *grid,
@@ -1010,6 +1025,8 @@ eos_flexy_grid_set_sort_func (EosFlexyGrid         *grid,
  * Sets the size of the cells of @grid.
  *
  * If @size is less than 0, the default size will be used.
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 void
 eos_flexy_grid_set_cell_size (EosFlexyGrid *grid,
@@ -1033,6 +1050,8 @@ eos_flexy_grid_set_cell_size (EosFlexyGrid *grid,
  * Retrieves the size of the cells of @grid.
  *
  * Return value: the size of the cells
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 guint
 eos_flexy_grid_get_cell_size (EosFlexyGrid *grid)
@@ -1055,6 +1074,8 @@ eos_flexy_grid_get_cell_size (EosFlexyGrid *grid)
  * Sets the spacing between each cell of @grid.
  *
  * If @spacing is less than 0, the default value will be used.
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 void
 eos_flexy_grid_set_cell_spacing (EosFlexyGrid *grid,
@@ -1078,6 +1099,8 @@ eos_flexy_grid_set_cell_spacing (EosFlexyGrid *grid,
  * Retrieves the cell spacing of @grid.
  *
  * Return value: the spacing between each cell
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 guint
 eos_flexy_grid_get_cell_spacing (EosFlexyGrid *grid)
@@ -1119,6 +1142,8 @@ do_grid_sort (gconstpointer row_a,
  * If @index_ is less than 0, the @child is appended at the end of the grid.
  *
  * If @index_ is 0, the child is prepended at the beginning of the grid.
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 void
 eos_flexy_grid_insert (EosFlexyGrid *grid,
@@ -1176,6 +1201,8 @@ eos_flexy_grid_insert (EosFlexyGrid *grid,
  * The coordinates to test must be in widget-relative space.
  *
  * Return value: (transfer none): the cell at the given coordinates, or %NULL
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 EosFlexyGridCell *
 eos_flexy_grid_get_cell_at_coords (EosFlexyGrid *grid,

--- a/endless/eosflexygrid.h
+++ b/endless/eosflexygrid.h
@@ -27,6 +27,8 @@ G_BEGIN_DECLS
  * EOS_STYLE_CLASS_FLEXY_GRID:
  *
  * A CSS class to match a grid with flexible layout, used by #EosFlexyGrid.
+ *
+ * Deprecated: 0.2: The #EosFlexyGrid widget should not be used in newly written code
  */
 #define EOS_STYLE_CLASS_FLEXY_GRID      "flexy-grid"
 /**
@@ -34,6 +36,8 @@ G_BEGIN_DECLS
  *
  * A CSS class to match a cell inside a grid with flexible layout, used by
  * #EosFlexyGrid.
+ *
+ * Deprecated: 0.2: The #EosFlexyGrid widget should not be used in newly written code
  */
 #define EOS_STYLE_CLASS_FLEXY_GRID_CELL "flexy-grid-cell"
 
@@ -41,6 +45,8 @@ G_BEGIN_DECLS
  * EosFlexyGrid:
  *
  * This structure contains no public members.
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 typedef struct _EosFlexyGrid            EosFlexyGrid;
 typedef struct _EosFlexyGridClass       EosFlexyGridClass;
@@ -49,6 +55,8 @@ typedef struct _EosFlexyGridClass       EosFlexyGridClass;
  * EosFlexyGridCell:
  *
  * This structure contains no public members.
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 typedef struct _EosFlexyGridCell        EosFlexyGridCell;
 typedef struct _EosFlexyGridCellClass   EosFlexyGridCellClass;
@@ -64,6 +72,8 @@ typedef struct _EosFlexyGridCellClass   EosFlexyGridCellClass;
  *
  * Returns: -1 if @cell_a should come before @cell_b, 1 if @cell_a should come
  * after @cell_b, or 0 if @cell_a and @cell_b are identical.
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 typedef gint (* EosFlexyGridSortFunc) (EosFlexyGridCell *cell_a,
                                        EosFlexyGridCell *cell_b,
@@ -88,31 +98,31 @@ struct _EosFlexyGridClass
   gpointer _padding[8];
 };
 
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 GType eos_flexy_grid_get_type (void) G_GNUC_CONST;
 
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 GtkWidget *             eos_flexy_grid_new                      (void);
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 void                    eos_flexy_grid_set_cell_size            (EosFlexyGrid         *grid,
                                                                  int                   size);
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 guint                   eos_flexy_grid_get_cell_size            (EosFlexyGrid         *grid);
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 void                    eos_flexy_grid_set_cell_spacing         (EosFlexyGrid         *grid,
                                                                  int                   spacing);
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 guint                   eos_flexy_grid_get_cell_spacing         (EosFlexyGrid         *grid);
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 void                    eos_flexy_grid_insert                   (EosFlexyGrid         *grid,
                                                                  GtkWidget            *child,
                                                                  int                   index_);
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 void                    eos_flexy_grid_set_sort_func            (EosFlexyGrid         *grid,
                                                                  EosFlexyGridSortFunc  sort_func,
                                                                  gpointer              data,
                                                                  GDestroyNotify        notify);
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 EosFlexyGridCell *      eos_flexy_grid_get_cell_at_coords       (EosFlexyGrid         *grid,
                                                                  double                x_pos,
                                                                  double                y_pos);
@@ -133,17 +143,17 @@ struct _EosFlexyGridCellClass
   gpointer _padding[8];
 };
 
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 GType eos_flexy_grid_cell_get_type (void) G_GNUC_CONST;
 
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 GtkWidget *     eos_flexy_grid_cell_new                 (void);
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 void            eos_flexy_grid_cell_set_shape           (EosFlexyGridCell *cell,
                                                          EosFlexyShape     shape);
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 EosFlexyShape   eos_flexy_grid_cell_get_shape           (EosFlexyGridCell *cell);
-EOS_SDK_AVAILABLE_IN_0_0
+EOS_SDK_DEPRECATED_IN_0_2_FOR (GtkGrid)
 gboolean        eos_flexy_grid_cell_get_selected        (EosFlexyGridCell *cell);
 
 G_END_DECLS

--- a/endless/eosflexygridcell.c
+++ b/endless/eosflexygridcell.c
@@ -2,6 +2,7 @@
 
 #include "config.h"
 
+#define EOS_SDK_DISABLE_DEPRECATION_WARNINGS
 #include "eosflexygrid-private.h"
 
 #include <glib-object.h>
@@ -119,6 +120,8 @@ eos_flexy_grid_cell_init (EosFlexyGridCell *self)
  * Creates a new #EosFlexyGridCell widget.
  *
  * Return value: (transfer full): the newly created #EosFlexyGridCell widget
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 GtkWidget *
 eos_flexy_grid_cell_new (void)
@@ -133,6 +136,8 @@ eos_flexy_grid_cell_new (void)
  *
  * Sets the shape of the @cell. The @shape determines the amount of
  * space inside a #EosFlexyGrid that will be assigned to the @cell.
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 void
 eos_flexy_grid_cell_set_shape (EosFlexyGridCell *cell,
@@ -160,6 +165,8 @@ eos_flexy_grid_cell_set_shape (EosFlexyGridCell *cell,
  * Retrieves the shape of @cell.
  *
  * Return value: the shape of the #EosFlexyGridCell
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 EosFlexyShape
 eos_flexy_grid_cell_get_shape (EosFlexyGridCell *cell)
@@ -179,6 +186,8 @@ eos_flexy_grid_cell_get_shape (EosFlexyGridCell *cell)
  * @iter: a #GSequenceIter
  *
  * The #GSequenceIter associated to @cell.
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 void
 eos_flexy_grid_cell_set_iter (EosFlexyGridCell *cell,
@@ -196,6 +205,8 @@ eos_flexy_grid_cell_set_iter (EosFlexyGridCell *cell,
  * Retrieves the #GSequenceIter associated to @cell.
  *
  * Return value: (transfer none): a #GSequenceIter
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 GSequenceIter *
 eos_flexy_grid_cell_get_iter (EosFlexyGridCell *cell)
@@ -211,6 +222,8 @@ eos_flexy_grid_cell_get_iter (EosFlexyGridCell *cell)
  * @selected: %TRUE to select the @cell, and %FALSE otherwise
  *
  * Sets whether the @cell should be selected or not.
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 void
 eos_flexy_grid_cell_set_selected (EosFlexyGridCell *cell,
@@ -235,6 +248,8 @@ eos_flexy_grid_cell_set_selected (EosFlexyGridCell *cell,
  *
  * Return value: %TRUE if the #EosFlexyGridCell is selected,
  *   and %FALSE otherwise
+ *
+ * Deprecated: 0.2: Use a #GtkGrid instead
  */
 gboolean
 eos_flexy_grid_cell_get_selected (EosFlexyGridCell *cell)


### PR DESCRIPTION
It's unused, and we should put it on notice before removing it.

[endlessm/eos-sdk#2733]
