### PR TITLE
Generate XML reports when running on Jenkins

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -201,6 +201,16 @@ AM_COND_IF([ENABLE_JS_DOC], [], [can_make_dist=no])
 AM_CONDITIONAL([CAN_MAKE_DIST], [test "x$can_make_dist" = "xyes"])
 AC_MSG_RESULT([$can_make_dist])
 
+# JASMINE_JUNIT_REPORTS_DIR: Where to put test reports
+AC_MSG_CHECKING([where to put test reports])
+AC_ARG_VAR([JASMINE_JUNIT_REPORTS_DIR], [Where to put test reports])
+AS_IF([test -n "$JASMINE_JUNIT_REPORTS_DIR"],
+	[JASMINE_REPORT_ARGUMENT="--junit $JASMINE_JUNIT_REPORTS_DIR/\$\${log/%.log/.js.xml}"
+	AC_MSG_RESULT([in $JASMINE_JUNIT_REPORTS_DIR])],
+	[JASMINE_REPORT_ARGUMENT=
+	AC_MSG_RESULT([nowhere])])
+AC_SUBST([JASMINE_REPORT_ARGUMENT])
+
 # Required libraries
 # ------------------
 PKG_CHECK_MODULES([EOS_SDK], [

--- a/test/Makefile.am.inc
+++ b/test/Makefile.am.inc
@@ -64,6 +64,7 @@ AM_JS_LOG_FLAGS = \
 	--include-path=$(top_srcdir)/webhelper \
 	--include-path=$(top_srcdir) \
 	--tap \
+	@JASMINE_REPORT_ARGUMENT@ \
 	--no-config \
 	$(NULL)
 LOG_COMPILER = gtester


### PR DESCRIPTION
If we detect a Jenkins environment using the environment variable
JASMINE_JUNIT_REPORTS_DIR that we set in the job's configuration, then
generate XML test reports for each Jasmine unit test.

[endlessm/eos-sdk#3172]
