### PR TITLE
Add WebHelper2 to eos-sdk-0-webhelper package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,10 +7,11 @@ Build-Depends: autotools-dev,
                eos-node-modules-dev (>= 1.0.0),
                gettext (>= 0.18.1),
                gir1.2-gdkpixbuf-2.0,
+               gir1.2-glib-2.0,
                gir1.2-gtk-3.0 (>= 3.8),
                gir1.2-json-1.0,
                gir1.2-webkit-3.0 (>= 2.0),
-               gir1.2-webkit2-3.0 (>= 2.0),
+               gir1.2-webkit2-4.0,
                gjs (>= 1.40),
                adwaita-icon-theme,
                gobject-introspection,
@@ -86,12 +87,15 @@ Description: Endless SDK
 
 Package: eos-sdk-0-webhelper
 Section: non-free/libs
-Architecture: all
+Architecture: any
 Depends: ${misc:Depends},
+         ${shlibs:Depends},
          gir1.2-endless-0 (= ${binary:Version}),
+         gir1.2-glib-2.0,
          gir1.2-gtk-3.0 (>= 3.8),
+         gir1.2-webhelper2private-1.0 (= ${binary:Version}),
          gir1.2-webkit-3.0 (>= 2.0),
-         gir1.2-webkit2-3.0 (>= 2.0),
+         gir1.2-webkit2-4.0,
          gjs
 Replaces: eos-sdk-webhelper
 Provides: eos-sdk-webhelper
@@ -99,6 +103,15 @@ Conflicts: eos-sdk-webhelper
 Description: Endless SDK web helper
  Internal convenience library to simplify creation of web apps using the
  Endless SDK.
+
+Package: gir1.2-webhelper2private-1.0
+Section: non-free/introspection
+Architecture: any
+Depends: ${gir:Depends},
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: Endless SDK web helper
+ "Private" library used by WebHelper.
 
 Package: eos-sdk-0-bin
 Section: non-free/libdevel

--- a/debian/eos-sdk-0-dev.install
+++ b/debian/eos-sdk-0-dev.install
@@ -2,4 +2,5 @@ usr/include/endless*/*
 usr/lib/pkgconfig/endless*.pc
 usr/lib/libendless*.so
 usr/share/gir-1.0/Endless*.gir
+usr/share/gir-1.0/WebHelper2Private-1.0.gir
 usr/share/aclocal/eos-*.m4

--- a/debian/eos-sdk-0-webhelper.install
+++ b/debian/eos-sdk-0-webhelper.install
@@ -1,1 +1,2 @@
-usr/share/gjs-1.0/webhelper.js
+usr/lib/eos-sdk/webhelper2/wh2extension.so
+usr/share/gjs-1.0/webhelper*

--- a/debian/gir1.2-webhelper2private-1.0.install
+++ b/debian/gir1.2-webhelper2private-1.0.install
@@ -1,0 +1,2 @@
+usr/lib/libwebhelper2private.so
+usr/lib/girepository-1.0/WebHelper2Private-1.0.typelib

--- a/debian/gir1.2-webhelper2private-1.0.postinst
+++ b/debian/gir1.2-webhelper2private-1.0.postinst
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    configure)
+        ldconfig
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+        ;;
+esac

--- a/debian/gir1.2-webhelper2private-1.0.postrm
+++ b/debian/gir1.2-webhelper2private-1.0.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    remove)
+        ldconfig
+        ;;
+    purge|upgrade|disappear|failed-upgrade|abort-install|abort-upgrade)
+        ;;
+esac


### PR DESCRIPTION
Note. Yes, it would seem that dh_auto_configure really does specify
--libexecdir=$(pkglibdir) which is terribly confusing, but fighting the
tools is an even worse idea.

[endlessm/eos-sdk#291]
