### PR TITLE
Clean stderr.log

### DIFF
--- a/test/Makefile.am.inc
+++ b/test/Makefile.am.inc
@@ -75,6 +75,7 @@ EXTRA_DIST += \
 	test/run-with-dbus \
 	test/test-bus.conf \
 	$(NULL)
+CLEANFILES += stderr.log
 
 # Use locally built versions of Endless-0.gir and libraries; this may need to be
 # changed to AM_TESTS_ENVIRONMENT in a future version of Automake


### PR DESCRIPTION
The run-with-dbus script can produce stderr.log, so we should clean it
out during 'make clean'.

[endlessm/eos-sdk#291]
