### PR TITLE
Install eos-html-extractor and add dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Build-Depends: at-spi2-core,
                libjson-glib-dev,
                libwebkit2gtk-4.0-dev,
                python-lcov-cobertura (>= 1.5),
+               python3-bs4,
                pkg-config (>= 0.24),
                naturaldocs,
                yelp-tools,
@@ -122,7 +123,8 @@ Architecture: all
 Depends: ${misc:Depends},
          gir1.2-glib-2.0,
          gir1.2-json-1.0,
-         gjs
+         gjs,
+         python3-bs4
 Replaces: eos-sdk-bin
 Provides: eos-sdk-bin
 Conflicts: eos-sdk-bin

--- a/debian/eos-sdk-0-bin.install
+++ b/debian/eos-sdk-0-bin.install
@@ -1,1 +1,2 @@
+usr/bin/eos-html-extractor
 usr/bin/eos-json-extractor


### PR DESCRIPTION
eos-html-extractor introduces a dependency on python3-bs4.

[endlessm/eos-sdk#3245]
