### PR TITLE
Ensure stdout is UTF-8

### DIFF
--- a/tools/eos-html-extractor
+++ b/tools/eos-html-extractor
@@ -3,6 +3,7 @@
 # Copyright 2013-2015 Endless Mobile, Inc.
 
 import argparse
+import io
 import os.path
 import re
 import sys
@@ -42,13 +43,16 @@ class TranslatableHTMLParser(HTMLParser):
     def handle_comment(self, comment):
         self._comments_with_line_numbers.append((comment, self.getpos()[0]))
 
+# Ensure stdout is UTF-8
+default_out = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+
 parser = argparse.ArgumentParser(description='Extract translatable strings ' +
     'from HTML files. This is xgettext for HTML.')
 parser.add_argument('input_file', type=str,
     help='Input file to scan')
 parser.add_argument('top_srcdir', type=str, nargs='?', default='.',
     help='Top-level source directory (for printing correct #line directives)')
-parser.add_argument('-o', '--output', default=sys.stdout,
+parser.add_argument('-o', '--output', default=default_out,
     type=argparse.FileType('w', encoding='utf-8'),
     help='File to write (default: stdout)')
 args = parser.parse_args()


### PR DESCRIPTION
This gets the underlying byte stream of sys.stdout and wraps it in a
UTF-8 encoder. That is then used as the default output file rather than
sys.stdout itself, which on Jenkins may not have a default encoding of
UTF-8.

[endlessm/eos-sdk#3245]
