### PR TITLE
Access static method on class, not instance

### DIFF
--- a/overrides/endless_private/topbar_nav_button.js
+++ b/overrides/endless_private/topbar_nav_button.js
@@ -25,7 +25,7 @@ const TopbarNavButton = new Lang.Class({
 
         let back_button_image;
         let forward_button_image;
-        let is_rtl = this.get_default_direction() === Gtk.TextDirection.RTL ? true : false;
+        let is_rtl = (Gtk.Widget.get_default_direction() === Gtk.TextDirection.RTL);
         if (is_rtl) {
             back_button_image = 'topbar-go-previous-rtl-symbolic';
             forward_button_image = 'topbar-go-next-rtl-symbolic';


### PR DESCRIPTION
The old GJS allowed you to access static methods on an instance of the
class that defined them. Not so with the new GJS. So instead of
any_widget.get_default_direction(), we now must do
Gtk.Widget.get_default_direction().

[endlessm/eos-sdk#3265]
