### PR TITLE
css: restore border-radius and box-shadow for tooltips

### DIFF
--- a/data/css/endless-widgets.css
+++ b/data/css/endless-widgets.css
@@ -33,6 +33,11 @@ EosWindow {
     box-shadow: 0 2px 5px 1px @endless_wm_shadow;
 }
 
+.window-frame.tooltip {
+    border-radius: 5px;
+    box-shadow: none;
+}
+
 /* Endless window top bar */
 
 .top-bar {


### PR DESCRIPTION
Don't let the .window-frame style we specify for SDK's client-decorated
windows also affect tooltips.

[endlessm/eos-sdk#3224]
