### PR TITLE
search_box: add function to set text programmatically

### DIFF
--- a/overrides/endless_private/search_box.js
+++ b/overrides/endless_private/search_box.js
@@ -141,6 +141,16 @@ const SearchBox = new Lang.Class({
         return Gdk.EVENT_STOP;
     },
 
+    /* Set the entry text without triggering the text-changed signal.
+    */
+    set_text_programmatically: function (text) {
+        if (this.text === text)
+            return;
+        this._entry_changed_by_widget = true;
+        this.text = text;
+        this.set_position(-1);
+    },
+
     /* Set the menu items by providing an array of item objects:
         [
             {

--- a/test/Makefile.am.inc
+++ b/test/Makefile.am.inc
@@ -52,10 +52,12 @@ javascript_tests = \
 	test/webhelper/testUpdateFontSize.js \
 	test/endless/testCustomContainer.js \
 	test/endless/testTopbarNavButton.js \
+	test/endless/testSearchBox.js \
 	$(NULL)
 EXTRA_DIST += \
 	$(javascript_tests) \
 	test/tools/test.html \
+	test/utils.js \
 	$(NULL)
 
 # Run tests when running 'make check'

--- a/test/endless/testSearchBox.js
+++ b/test/endless/testSearchBox.js
@@ -1,0 +1,20 @@
+const Endless = imports.gi.Endless;
+const Gtk = imports.gi.Gtk;
+
+const Utils = imports.test.utils;
+
+Gtk.init(null);
+
+describe('SearchBox', function () {
+    let search_box;
+
+    beforeEach(function () {
+        search_box = new Endless.SearchBox();
+    });
+
+    it('emits no signal when you change the text programmatically', function () {
+        search_box.connect('text-changed', () => fail());
+        search_box.set_text_programmatically('some text');
+        Utils.update_gui();
+    });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,6 @@
+const Gtk = imports.gi.Gtk;
+
+function update_gui () {
+    while (Gtk.events_pending())
+        Gtk.main_iteration(false);
+}


### PR DESCRIPTION
This way we can set the search box text without triggering the
signals for settings autocomplete entries
[endlessm/eos-sdk#3442]
[endlessm/eos-sdk#3160]
