### PR TITLE
Debian changes for WebKit2-3.0-compatible WebHelper

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Build-Depends: at-spi2-core,
                gir1.2-gtk-3.0 (>= 3.8),
                gir1.2-json-1.0,
                gir1.2-webkit-3.0 (>= 2.0),
+               gir1.2-webkit2-3.0,
                gir1.2-webkit2-4.0,
                gjs (>= 1.40),
                adwaita-icon-theme,
@@ -23,6 +24,7 @@ Build-Depends: at-spi2-core,
                libglib2.0-bin,
                libgtk-3-dev,
                libjson-glib-dev,
+               libwebkit2gtk-3.0-dev,
                libwebkit2gtk-4.0-dev,
                python-lcov-cobertura (>= 1.5),
                python3,
@@ -99,6 +101,7 @@ Depends: ${misc:Depends},
          gir1.2-gtk-3.0 (>= 3.8),
          gir1.2-webhelper2private-1.0 (= ${binary:Version}),
          gir1.2-webkit-3.0 (>= 2.0),
+         gir1.2-webkit2-3.0,
          gir1.2-webkit2-4.0,
          gjs
 Replaces: eos-sdk-webhelper
@@ -109,6 +112,15 @@ Description: Endless SDK web helper
  Endless SDK.
 
 Package: gir1.2-webhelper2private-1.0
+Section: non-free/introspection
+Architecture: any
+Depends: ${gir:Depends},
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: Endless SDK web helper
+ "Private" library used by WebHelper.
+
+Package: gir1.2-webhelper2oldprivate-1.0
 Section: non-free/introspection
 Architecture: any
 Depends: ${gir:Depends},

--- a/debian/eos-sdk-0-dev.install
+++ b/debian/eos-sdk-0-dev.install
@@ -3,4 +3,5 @@ usr/lib/pkgconfig/endless*.pc
 usr/lib/libendless*.so
 usr/share/gir-1.0/Endless*.gir
 usr/share/gir-1.0/WebHelper2Private-1.0.gir
+usr/share/gir-1.0/WebHelper2OldPrivate-1.0.gir
 usr/share/aclocal/eos-*.m4

--- a/debian/eos-sdk-0-webhelper.install
+++ b/debian/eos-sdk-0-webhelper.install
@@ -1,2 +1,3 @@
 usr/lib/eos-sdk/webhelper2/wh2extension.so
+usr/lib/eos-sdk/webhelper2old/wh2extension.so
 usr/share/gjs-1.0/webhelper*

--- a/debian/gir1.2-webhelper2oldprivate-1.0.install
+++ b/debian/gir1.2-webhelper2oldprivate-1.0.install
@@ -1,0 +1,2 @@
+usr/lib/libwebhelper2oldprivate.so
+usr/lib/girepository-1.0/WebHelper2OldPrivate-1.0.typelib

--- a/debian/gir1.2-webhelper2oldprivate-1.0.postinst
+++ b/debian/gir1.2-webhelper2oldprivate-1.0.postinst
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    configure)
+        ldconfig
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+        ;;
+esac

--- a/debian/gir1.2-webhelper2oldprivate-1.0.postrm
+++ b/debian/gir1.2-webhelper2oldprivate-1.0.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    remove)
+        ldconfig
+        ;;
+    purge|upgrade|disappear|failed-upgrade|abort-install|abort-upgrade)
+        ;;
+esac


### PR DESCRIPTION
We need a second GIR package, for WebHelper2OldPrivate-1.0, and some other
packages need dependencies on WebKit2-3.0.

[endlessm/eos-sdk#3430]
