### PR TITLE
Fix extension library name

### DIFF
--- a/debian/eos-sdk-0-webhelper.install
+++ b/debian/eos-sdk-0-webhelper.install
@@ -1,3 +1,3 @@
 usr/lib/eos-sdk/webhelper2/wh2extension.so
-usr/lib/eos-sdk/webhelper2old/wh2extension.so
+usr/lib/eos-sdk/webhelper2old/wh2oldextension.so
 usr/share/gjs-1.0/webhelper*


### PR DESCRIPTION
The Debian packaging broke because the .so file had the wrong name.

[endlessm/eos-sdk#3430]
