### PR TITLE
Use correct icon name for unmaximize button

### DIFF
--- a/endless/eostopbar.c
+++ b/endless/eostopbar.c
@@ -27,7 +27,7 @@
 #define _EOS_TOP_BAR_VERTICAL_BUTTON_MARGIN_PX 6
 #define _EOS_TOP_BAR_MINIMIZE_ICON_NAME "window-minimize-symbolic"
 #define _EOS_TOP_BAR_MAXIMIZE_ICON_NAME "window-maximize-symbolic"
-#define _EOS_TOP_BAR_UNMAXIMIZE_ICON_NAME "window-unmaximize-symbolic"
+#define _EOS_TOP_BAR_UNMAXIMIZE_ICON_NAME "window-restore-symbolic"
 #define _EOS_TOP_BAR_CLOSE_ICON_NAME "window-close-symbolic"
 #define _EOS_TOP_BAR_CREDITS_ICON_NAME "user-info-symbolic"
 


### PR DESCRIPTION
Since GTK 3.10, window-restore-symbolic has been the name for this icon,
not window-unmaximize-symbolic. We have recently changed eos-theme to
use the correct name, so we must change eos-sdk as well.

[endlessm/eos-shell#5567]
