### PR TITLE
Added eoslicense.c to POTFILES.in

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,3 +1,4 @@
 # List of source files which contain translatable strings.
 endless/eosapplication.c
 endless/eosattribution.c
+endless/eoslicense.c


### PR DESCRIPTION
We have a new translateable string on eoslicense.c, so it has to be marked for
localization.

[endlessm/eos-sdk#3577]
