### PR TITLE
Document new macros

### DIFF
--- a/docs/reference/endless/endless-docs.xml
+++ b/docs/reference/endless/endless-docs.xml
@@ -17,13 +17,14 @@
 
   <chapter>
     <title>Open Endless SDK reference (C API)</title>
-        <xi:include href="xml/application.xml"/>
-        <xi:include href="xml/window.xml"/>
-        <xi:include href="xml/page-manager.xml"/>
-        <xi:include href="xml/flexy-grid.xml"/>
-        <xi:include href="xml/custom-container.xml"/>
-        <xi:include href="xml/license.xml"/>
-        <!--<xi:include href="xml/hello.xml"/>-->
+    <xi:include href="xml/system.xml"/>
+    <xi:include href="xml/application.xml"/>
+    <xi:include href="xml/window.xml"/>
+    <xi:include href="xml/page-manager.xml"/>
+    <xi:include href="xml/flexy-grid.xml"/>
+    <xi:include href="xml/custom-container.xml"/>
+    <xi:include href="xml/license.xml"/>
+    <!--<xi:include href="xml/hello.xml"/>-->
   </chapter>
 
   <chapter id="object-tree">

--- a/docs/reference/endless/endless-sections.txt
+++ b/docs/reference/endless/endless-sections.txt
@@ -1,9 +1,13 @@
 <SECTION>
 <FILE>hello</FILE>
+eos_hello_sample_function
+</SECTION>
+
+<SECTION>
+<FILE>system</FILE>
 EOS_SDK_MAJOR_VERSION
 EOS_SDK_MINOR_VERSION
 EOS_SDK_MICRO_VERSION
-eos_hello_sample_function
 eos_get_system_personality
 <SUBSECTION Private>
 EOS_DEFINE_ENUM_TYPE

--- a/endless/eosversion.h.in
+++ b/endless/eosversion.h.in
@@ -7,6 +7,14 @@
 #endif
 
 /**
+ * SECTION:system
+ * @short_description: System utilities
+ * @title: System
+ *
+ * Miscellaneous utilities for gathering information about the system.
+ */
+
+/**
  * EOS_SDK_MAJOR_VERSION:
  *
  * Major version number (API level) of the Endless SDK library.


### PR DESCRIPTION
These were mistakenly added to a page that doesn't get included in the
documentation index. This creates a new page, "system", for utilities for
gathering information about the system.

[endlessm/eos-sdk#3071]
