### PR TITLE
Increase font size for search bar in composite

### DIFF
--- a/data/css/endless-widgets.css
+++ b/data/css/endless-widgets.css
@@ -214,3 +214,9 @@ EosWindow .titlebar .endless-search-box:selected {
     color: mix (@endless_menu_fg_color, @endless_menu_bg_color, 0.9);
     -GtkMenuItem-horizontal-padding: 0;
 }
+
+/* Changes for composite TVs */
+
+.composite .header-bar .entry {
+      font-size: 18px;
+  }


### PR DESCRIPTION
As per Design, the font size of the search bar widget should be 18px when in
composite mode.

Since all the apps should adopt this specification, it's better for it to live
here.

[endlessm/eos-sdk#3975]
