### PR TITLE
css: no resize when back/forward insensitive

### DIFF
--- a/data/css/endless-widgets.css
+++ b/data/css/endless-widgets.css
@@ -92,7 +92,9 @@ EosWindow .titlebar .forward {
     background-image: linear-gradient(-179deg,
         rgba(98, 98, 98, 0.49) 0%,
         alpha(black, 0.50) 100%);
-    border: 1px solid black;
+    border-style: solid;
+    border-width: 1px;
+    border-color: black;
     box-shadow: inset 1px 1px alpha(white, 0.25);
     padding: 2px 10px;
 }
@@ -100,7 +102,7 @@ EosWindow .titlebar .forward {
 EosWindow .titlebar .home:insensitive,
 EosWindow .titlebar .back:insensitive,
 EosWindow .titlebar .forward:insensitive {
-    border: 1px solid alpha(black, 0.20);
+    border-color: alpha(black, 0.20);
     background-color: transparent;
     background-image: none;
     box-shadow: none;


### PR DESCRIPTION
We can rewrite the style update so it won't trigger a size change
[endlessm/eos-sdk#3590]
