### PR TITLE
Install and configure Arcanist

### DIFF
--- a/ansible/playbooks/setup_other_tools.yaml
+++ b/ansible/playbooks/setup_other_tools.yaml
@@ -16,3 +16,9 @@
 
 - name: "Installing transifex client"
   shell: pip install transifex-client
+
+- name: "Installing Arcanist"
+  apt: name=arcanist
+
+- name: "Configuring Arcanist"
+  shell: arc set-config default https://phabricator.endlessm.com


### PR DESCRIPTION
This points Arcanist by default to https://phabricator.endlessm.com.

https://phabricator.endlessm.com/T10968
