### PR TITLE
Do not explicitly lookup an RTL icon for the topbar's home icon

### DIFF
--- a/overrides/endless_private/topbar_home_button.js
+++ b/overrides/endless_private/topbar_home_button.js
@@ -19,12 +19,7 @@ const TopbarHomeButton = new Lang.Class({
     _init: function(props={}) {
         this.parent(props);
 
-        let icon_name;
-        if (Gtk.Widget.get_default_direction() === Gtk.TextDirection.RTL) {
-            icon_name = 'go-home-rtl-symbolic';
-        } else {
-            icon_name = 'go-home-symbolic';
-        }
+        let icon_name = 'go-home-symbolic';
         let image = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.SMALL_TOOLBAR);
         this.set_image(image);
 


### PR DESCRIPTION
GTK+ >= 3.12 will do that automatically by appending a '-rtl'
suffix to the icon name when needed.

https://phabricator.endlessm.com/T11002
