### PR TITLE
topbar_nav_button: use standard upstream icons

### DIFF
--- a/overrides/endless_private/topbar_nav_button.js
+++ b/overrides/endless_private/topbar_nav_button.js
@@ -23,25 +23,15 @@ const TopbarNavButton = new Lang.Class({
         props.orientation = Gtk.Orientation.HORIZONTAL;
         this.parent(props);
 
-        let back_button_image;
-        let forward_button_image;
-        let is_rtl = (Gtk.Widget.get_default_direction() === Gtk.TextDirection.RTL);
-        if (is_rtl) {
-            back_button_image = 'topbar-go-previous-rtl-symbolic';
-            forward_button_image = 'topbar-go-next-rtl-symbolic';
-        } else {
-            back_button_image = 'topbar-go-previous-symbolic';
-            forward_button_image = 'topbar-go-next-symbolic';
-        }
-
-        this._back_button = Gtk.Button.new_from_icon_name(back_button_image,
+        this._back_button = Gtk.Button.new_from_icon_name('go-previous-symbolic',
             Gtk.IconSize.SMALL_TOOLBAR);
-        this._forward_button = Gtk.Button.new_from_icon_name(forward_button_image,
+        this._forward_button = Gtk.Button.new_from_icon_name('go-next-symbolic',
             Gtk.IconSize.SMALL_TOOLBAR);
 
         this._back_button.get_style_context().add_class('back');
         this._forward_button.get_style_context().add_class('forward');
 
+        let is_rtl = (Gtk.Widget.get_default_direction() === Gtk.TextDirection.RTL);
         if (is_rtl) {
             this._back_button.get_style_context().add_class('rtl');
             this._forward_button.get_style_context().add_class('rtl');


### PR DESCRIPTION
Instead of our own, which are nearly identical.
Also, remove our RTL special case for icon names, since recent GTK does
it for us automatically.

https://phabricator.endlessm.com/T11778
