### PR TITLE
T12150

### DIFF
--- a/endless/Makefile.am
+++ b/endless/Makefile.am
@@ -64,6 +64,7 @@ libendless_@EOS_SDK_API_VERSION@_la_SOURCES = \
 # G_MESSAGES_DEBUG=EndlessSDK ./myprogram
 # and turn on debug messages
 libendless_@EOS_SDK_API_VERSION@_la_CPPFLAGS = \
+	-I$(builddir)/endless \
 	@EOS_SDK_CFLAGS@ \
 	-DG_LOG_DOMAIN=\"EndlessSDK\" \
 	-DCOMPILING_EOS_SDK \

--- a/test/Makefile.am.inc
+++ b/test/Makefile.am.inc
@@ -1,6 +1,6 @@
 # Copyright 2013 Endless Mobile, Inc.
 
-TEST_FLAGS = @EOS_SDK_CFLAGS@ -I$(top_srcdir) -DCOMPILING_EOS_SDK
+TEST_FLAGS = @EOS_SDK_CFLAGS@ -I$(builddir)/endless  -I$(top_srcdir) -DCOMPILING_EOS_SDK
 TEST_LIBS = @EOS_SDK_LIBS@ $(top_builddir)/libendless-@EOS_SDK_API_VERSION@.la
 
 noinst_PROGRAMS = \


### PR DESCRIPTION
Fix eos-sdk build for out of tree builds (jhbuild master)

Include $(buildir)/endless directory in per-executable/library _CPPFLAGS
since global AM_CPPFLAGS is ignored in those cases.

https://phabricator.endlessm.com/T12150
