### PR TITLE
Make metrics dependency optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,7 @@ EOSMETRICS_REQUIREMENT="eosmetrics-0"
 # These go into the pkg-config file as Requires: and Requires.private:
 # (Generally, use Requires.private: instead of Requires:)
 EOS_REQUIRED_MODULES=
-EOS_REQUIRED_MODULES_PRIVATE="$GLIB_REQUIREMENT $GOBJECT_REQUIREMENT $GIO_REQUIREMENT $GTK_REQUIREMENT $JSON_GLIB_REQUIREMENT $EOSMETRICS_REQUIREMENT"
+EOS_REQUIRED_MODULES_PRIVATE="$GLIB_REQUIREMENT $GOBJECT_REQUIREMENT $GIO_REQUIREMENT $GTK_REQUIREMENT $JSON_GLIB_REQUIREMENT"
 AC_SUBST(EOS_REQUIRED_MODULES)
 AC_SUBST(EOS_REQUIRED_MODULES_PRIVATE)
 
@@ -170,6 +170,16 @@ AS_CASE([$enable_strict_flags],
 dnl Strip leading spaces
 STRICT_CFLAGS=${STRICT_CFLAGS#*  }
 AC_SUBST(STRICT_CFLAGS)
+
+# --disable-metrics: Don't send metrics to Endless, avoid eos-metrics
+# dependency.
+AH_TEMPLATE([USE_METRICS], [Define this to 1 if you want to include support in
+	the library for sending metrics to Endless])
+AC_ARG_ENABLE([metrics], [AS_HELP_STRING([--disable-metrics],
+	[Sending metrics requires eos-metrics dependency @<:@default=yes@:>@])])
+AS_IF([test "x$enable_metrics" != "xno"], [
+	AC_DEFINE([USE_METRICS])
+	EOS_REQUIRED_MODULES_PRIVATE="$EOS_REQUIRED_MODULES_PRIVATE $EOSMETRICS_REQUIREMENT"])
 
 # --enable-gir-doc: Build GIR documentation for Javascript. Done automatically
 # during 'make distcheck'.

--- a/endless/eoswindow.c
+++ b/endless/eoswindow.c
@@ -6,7 +6,10 @@
 #include "eostopbar-private.h"
 
 #include <gtk/gtk.h>
+
+#ifdef USE_METRICS
 #include <eosmetrics/eosmetrics.h>
+#endif
 
 /**
  * SECTION:window
@@ -647,6 +650,8 @@ update_screen (EosWindow *self)
     gtk_style_context_remove_class (context, EOS_STYLE_CLASS_COMPOSITE);
 }
 
+#ifdef USE_METRICS
+
 static gboolean
 record_unmaximize_metric (EosWindow *self)
 {
@@ -688,6 +693,8 @@ on_maximize_state_change (EosWindow  *self,
                                self);
     }
 }
+
+#endif /* USE_METRICS */
 
 static void
 on_credits_clicked (GtkWidget *top_bar,
@@ -790,8 +797,10 @@ eos_window_init (EosWindow *self)
   g_signal_connect (priv->top_bar, "credits-clicked",
                     G_CALLBACK (on_credits_clicked), self);
   g_signal_connect (self, "notify::screen", G_CALLBACK (update_screen), NULL);
+#ifdef USE_METRICS
   g_signal_connect (self, "notify::is-maximized",
                     G_CALLBACK(on_maximize_state_change), NULL);
+#endif
 
   eos_window_set_page_manager (self,
                                EOS_PAGE_MANAGER (eos_page_manager_new ()));


### PR DESCRIPTION
We should allow external contributors to build eos-sdk without the
eos-metrics dependency.

https://phabricator.endlessm.com/T13015