### PR TITLE
Fix the EXTRA_DIST listing in tests

### DIFF
--- a/test/Makefile.am.inc
+++ b/test/Makefile.am.inc
@@ -86,7 +86,7 @@ AM_JS_LOG_FLAGS = \
 LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/tap-driver.sh
 LOG_COMPILER = $(top_srcdir)/test/tap-test.sh
 EXTRA_DIST += \
-	test/tap-test.sh
+	test/tap-test.sh \
 	test/run-with-dbus \
 	test/test-bus.conf \
 	$(NULL)


### PR DESCRIPTION
Missing '\'.