### PR TITLE
js: Declare module export variables with "var"

### DIFF
--- a/overrides/endless_private/asset_button.js
+++ b/overrides/endless_private/asset_button.js
@@ -5,7 +5,7 @@ const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const AssetButton = new Lang.Class({
+var AssetButton = new Lang.Class({
     Name: 'AssetButton',
     GTypeName: 'EosAssetButton',
     Extends: Gtk.Button,

--- a/overrides/endless_private/search_box.js
+++ b/overrides/endless_private/search_box.js
@@ -30,7 +30,7 @@ const TITLE_MAX_CHARS_DEFAULT = 255;
  * search box's alignment is set to Gtk.Align.FILL in either direction.
  *
  */
-const SearchBox = new Lang.Class({
+var SearchBox = new Lang.Class({
     Name: 'SearchBox',
     GTypeName: 'EosSearchBox',
     Extends: Gtk.Entry,

--- a/overrides/endless_private/topbar_home_button.js
+++ b/overrides/endless_private/topbar_home_button.js
@@ -11,7 +11,7 @@ const Lang = imports.lang;
  * clicked, the user must be re-directed to the home page of the
  * application.
  */
-const TopbarHomeButton = new Lang.Class({
+var TopbarHomeButton = new Lang.Class({
     Name: 'TopbarHomeButton',
     GTypeName: 'EosTopbarHomeButton',
     Extends: Gtk.Button,

--- a/overrides/endless_private/topbar_nav_button.js
+++ b/overrides/endless_private/topbar_nav_button.js
@@ -3,7 +3,7 @@ const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
 
-const TopbarNavButton = new Lang.Class({
+var TopbarNavButton = new Lang.Class({
     Name: 'TopbarNavButton',
     GTypeName: 'EosTopbarNavButton',
     Extends: Gtk.Grid,


### PR DESCRIPTION
In ES6, variables declared with "const" and "let" go into the "lexical
scope" rather than the normal scope. Therefore, they are not available as
properties on modules. GJS preserves the old behaviour with a warning,
but we should fix our code anyway.

https://phabricator.endlessm.com/T18106