### PR TITLE
customcontainer: Queue resize if visible child removed

### DIFF
--- a/endless/eoscustomcontainer.c
+++ b/endless/eoscustomcontainer.c
@@ -67,8 +67,13 @@ eos_custom_container_remove (GtkContainer *container,
   EosCustomContainer *self = EOS_CUSTOM_CONTAINER (container);
   EosCustomContainerPrivate *priv = eos_custom_container_get_instance_private (self);
 
+  gboolean needs_resize = gtk_widget_get_visible (child);
+
   priv->children = g_list_remove (priv->children, child);
   gtk_widget_unparent (child);
+
+  if (needs_resize)
+    gtk_widget_queue_resize (GTK_WIDGET (container));
 }
 
 static void


### PR DESCRIPTION
All custom containers previously needed to do this in Javascript, but
that caused problems: garbage collection could cause widgets to be
removed, and you cannot trigger Javascript code to run during garbage
collection.

https://phabricator.endlessm.com/T18286