### PR TITLE
build: Fix make distcheck

### DIFF
--- a/test/Makefile.am.inc
+++ b/test/Makefile.am.inc
@@ -76,7 +76,6 @@ LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/tap-driver.sh
 LOG_COMPILER = $(top_srcdir)/test/tap-test.sh
 EXTRA_DIST += \
 	test/tap-test.sh \
-	test/run-with-dbus \
 	test/test-bus.conf \
 	$(NULL)
 CLEANFILES += stderr.log


### PR DESCRIPTION
run-with-dbus was removed, but still referred to in dist-files.

https://phabricator.endlessm.com/T18981