### PR TITLE
EosWindow: add in-resize css class

### DIFF
--- a/data/css/endless-widgets.css
+++ b/data/css/endless-widgets.css
@@ -20,6 +20,10 @@ EosWindow {
     background-color: @endless_theme_bg_color;
 }
 
+EosWindow.in-resize {
+    image-rendering: crisp-edges;
+}
+
 .window-frame {
     border-color: darker(@endless_theme_bg_color);
     border-radius: 7px 7px 0 0;


### PR DESCRIPTION
Add class while window is being resized to change image scaling method in CSS
This would speed up resizing windows with background images.

https://phabricator.endlessm.com/T20677