### PR TITLE
SearchBox: Get correct index from selected match

### DIFF
--- a/overrides/endless_private/search_box.js
+++ b/overrides/endless_private/search_box.js
@@ -153,7 +153,7 @@ var SearchBox = new Lang.Class({
     },
 
     _onMatchSelected: function (widget, model, iter) {
-        let index = model.get_path(iter).get_indices();
+        let index = model.get_path(iter).get_indices()[0];
         this.emit('menu-item-selected', this._items[index]['id']);
         return Gdk.EVENT_STOP;
     },


### PR DESCRIPTION
When clicking on a result from the autocomplete popup, we should select
the first index of the tree path. (The list is a flat list, so there is
always only one index.)

This prevents a warning about a missing property of
[Symbol.toPrimitive], because we were indexing this._items with the
indices array (which is not a primitive) instead of its first item.

https://phabricator.endlessm.com/T21027