### PR TITLE
Remove custom titlebar styles (T21463)

### DIFF
--- a/data/css/endless-widgets.css
+++ b/data/css/endless-widgets.css
@@ -1,144 +1,18 @@
 /* Wipe all theming CSS to start with. We'll leave the adwaita theme for
  * spinner.*/
-EosWindow,
-EosWindow :not(spinner):not(decoration) {
+.eos-window-inner :not(spinner):not(decoration),
+.eos-reset,
+.eos-reset :not(spinner):not(decoration) {
     all: unset;
-}
-
-@define-color endless_theme_bg_color #2e3436;
-@define-color endless_wm_shadow alpha(black, 0.5);
-
-/* Insensitive Text */
-
-menu label:disabled {
-    color: rgba(255, 255, 255, 0.5);
-}
-
-/* Endless app window */
-
-EosWindow {
-    background-color: @endless_theme_bg_color;
 }
 
 EosWindow.in-resize {
     -eos-cairo-filter: -eos-nearest;
 }
 
-.window-frame {
-    border-color: darker(@endless_theme_bg_color);
-    border-radius: 7px 7px 0 0;
-    border-width: 1px;
-    border-style: solid;
-
-    box-shadow: 0 2px 8px 3px @endless_wm_shadow;
-
-    /* this is used for the resize cursor area */
-    margin: 10px;
-}
-
-.window-frame:backdrop {
-    box-shadow: 0 2px 5px 1px @endless_wm_shadow;
-}
-
-.window-frame.tooltip {
-    border-radius: 5px;
-    box-shadow: none;
-}
-
-EosWindow .titlebar {
-    font-family: "Lato";
-    font-weight: bold;
-    font-size: 14.7px;
-    background-image: -gtk-gradient(linear, center top, center bottom,
-        from(#464646), to(#1e1e1e));
-    padding-left: 7px;
-    padding-right: 7px;
-}
-
-EosWindow:not(.maximized) .titlebar {
-    border-radius: 7px 7px 0px 0px;
-}
-
-EosWindow .titlebar:backdrop {
-    background-image: -gtk-gradient(linear, center top, center bottom,
-        from(#282828), to(#1e1e1e));
-}
-
-EosWindow .titlebar button {
-    border-radius: 2px;
-    color: #8c8c8c;
-    -gtk-icon-shadow: 0px -1px alpha(black, 0.25);
-    padding: 4px;
-}
-
-EosWindow .titlebar button:backdrop {
-    color: #646464;
-}
-
-EosWindow .titlebar button:hover {
-    color: #dcdcdc;
-    -gtk-icon-shadow: 0px -1px alpha(black, 0.35);
-    background-image: -gtk-gradient(linear, left bottom, left top,
-        color-stop(0.98, rgb(131, 131, 131)),
-        color-stop(0.95, rgb(108, 108, 108)),
-        color-stop(0, rgb(68, 68, 68)));
-}
-
-EosWindow .titlebar button:active {
-    color: #787878;
-    -gtk-icon-shadow: none;
-    background-image: -gtk-gradient(linear, left bottom, left top,
-        color-stop(0.98, rgb(79, 79, 79)),
-        color-stop(0.95, rgb(71, 71, 71)),
-        color-stop(0, rgb(67, 67, 67)));
-}
-
-EosWindow .titlebar .home,
-EosWindow .titlebar .back,
-EosWindow .titlebar .forward {
-    background-image: linear-gradient(-179deg,
-        rgba(98, 98, 98, 0.49) 0%,
-        alpha(black, 0.50) 100%);
-    border-style: solid;
-    border-width: 1px;
-    border-color: black;
-    box-shadow: inset 1px 1px alpha(white, 0.25);
-    padding: 2px 10px;
-}
-
-EosWindow .titlebar .home:disabled,
-EosWindow .titlebar .back:disabled,
-EosWindow .titlebar .forward:disabled {
-    border-color: alpha(black, 0.20);
-    background-color: transparent;
-    background-image: none;
-    box-shadow: none;
-    color: #5a5a5a;
-    -gtk-icon-shadow: none;
-}
-
-EosWindow .titlebar .home {
-    border-radius: 5px;
-}
-
-EosWindow .titlebar .back {
-    border-top-left-radius: 5px;
-    border-bottom-left-radius: 5px;
-    border-right: 0px none;
-}
-
-EosWindow .titlebar .forward {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
-}
-
-EosWindow .titlebar .forward.rtl {
-    border-radius: 5px 0 0 5px;
-    border-right: 0px none;
-}
-
-EosWindow .titlebar .back.rtl {
-    border-radius: 0 5px 5px 0;
+EosWindow .titlebar .NavigationSearchBox {
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 .credits-button {
@@ -162,33 +36,33 @@ EosWindow .titlebar .back.rtl {
 @define-color endless_menu_fg_color #2e3436;
 @define-color endless_menu_bg_color shade (#ededed, 1.1);
 
-.context-menu {
+.eos-window-inner .context-menu {
     font: initial;
     color: @endless_menu_fg_color;
     background-color: @endless_menu_bg_color;
     padding: 2px 0px;
 }
 
-.context-menu menuitem {
+.eos-window-inner .context-menu menuitem {
     padding: 4px;
 }
 
-.context-menu menuitem arrow {
+.eos-window-inner .context-menu menuitem arrow {
     min-width: 8px;
     min-height: 8px;
 }
 
-.context-menu menuitem:active,
-.context-menu menuitem:hover {
+.eos-window-inner .context-menu menuitem:active,
+.eos-window-inner .context-menu menuitem:hover {
     color: #ffffff;
     background-color: #4a90d9;
 }
 
-.context-menu menuitem *:disabled {
+.eos-window-inner .context-menu menuitem *:disabled {
     color: mix (@endless_menu_fg_color, @endless_menu_bg_color, 0.6);
 }
 
-.context-menu separator {
+.eos-window-inner .context-menu separator {
     background-color: transparent;
     background-image: image(mix (@endless_menu_fg_color, @endless_menu_bg_color, 0.9));
     background-size: 1px 1px;

--- a/data/widgets/topbar.ui
+++ b/data/widgets/topbar.ui
@@ -6,9 +6,8 @@
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="custom_title">center_top_bar_attach</property>
-    <property name="hexpand">true</property>
     <property name="show_close_button">True</property>
-    <property name="spacing">8</property>
+    <property name="spacing">6</property>
     <child>
       <object class="GtkButton" id="credits_button">
         <property name="visible">False</property>

--- a/endless/eostopbar-private.h
+++ b/endless/eostopbar-private.h
@@ -36,12 +36,12 @@ typedef struct _EosTopBarClass EosTopBarClass;
 
 struct _EosTopBar
 {
-  GtkEventBox parent;
+  GtkHeaderBar parent;
 };
 
 struct _EosTopBarClass
 {
-  GtkEventBoxClass parent_class;
+  GtkHeaderBarClass parent_class;
 };
 
 GType      eos_top_bar_get_type                (void) G_GNUC_CONST;

--- a/endless/eostopbar.c
+++ b/endless/eostopbar.c
@@ -95,68 +95,6 @@ eos_top_bar_set_property (GObject      *object,
 }
 
 static void
-eos_top_bar_get_preferred_height (GtkWidget *widget,
-                                  int *minimum,
-                                  int *natural)
-{
-  gboolean left_widget_visible = FALSE, center_widget_visible = FALSE;
-  EosTopBar *self = EOS_TOP_BAR (widget);
-  EosTopBarPrivate *priv = eos_top_bar_get_instance_private (self);
-  if (priv->left_top_bar_widget)
-    {
-      left_widget_visible = gtk_widget_get_visible (priv->left_top_bar_widget);
-      gtk_widget_set_visible (priv->left_top_bar_widget, TRUE);
-    }
-  if (priv->center_top_bar_widget)
-    {
-      center_widget_visible = gtk_widget_get_visible (priv->center_top_bar_widget);
-      gtk_widget_set_visible (priv->center_top_bar_widget, TRUE);
-    }
-
-  GTK_WIDGET_CLASS (eos_top_bar_parent_class)->get_preferred_height (widget,
-                                                                     minimum,
-                                                                     natural);
-  if (minimum != NULL)
-    *minimum = MAX (_EOS_TOP_BAR_HEIGHT_PX, *minimum);
-  if (natural != NULL)
-    *natural = MAX (_EOS_TOP_BAR_HEIGHT_PX, *natural);
-
-  if (priv->left_top_bar_widget)
-    {
-      gtk_widget_set_visible (priv->left_top_bar_widget, left_widget_visible);
-    }
-  if (priv->center_top_bar_widget)
-    {
-      gtk_widget_set_visible (priv->center_top_bar_widget, center_widget_visible);
-    }
-}
-
-/* Draw the edge finishing on the two lines inside the topbar; see
-after_draw_cb() in eoswindow.c for the two lines outside the topbar */
-static gboolean
-eos_top_bar_draw (GtkWidget *self_widget,
-                  cairo_t   *cr)
-{
-  GTK_WIDGET_CLASS (eos_top_bar_parent_class)->draw (self_widget, cr);
-
-  gint width = gtk_widget_get_allocated_width (self_widget);
-  gint height = gtk_widget_get_allocated_height (self_widget);
-  cairo_set_line_width (cr, 1.0);
-  /* Highlight: #ffffff, opacity 5% */
-  cairo_set_source_rgba (cr, 1.0, 1.0, 1.0, 0.05);
-  cairo_move_to (cr, 0, height - 1.5);
-  cairo_rel_line_to (cr, width, 0);
-  cairo_stroke (cr);
-  /* Baseline: #0a0a0a, opacity 100% */
-  cairo_set_source_rgb (cr, 0.039, 0.039, 0.039);
-  cairo_move_to (cr, 0, height - 0.5);
-  cairo_rel_line_to (cr, width, 0);
-  cairo_stroke (cr);
-
-  return GDK_EVENT_PROPAGATE;
-}
-
-static void
 on_credits_clicked (GtkButton *button,
                     EosTopBar *self)
 {
@@ -172,8 +110,6 @@ eos_top_bar_class_init (EosTopBarClass *klass)
   object_class->constructed = eos_top_bar_constructed;
   object_class->get_property = eos_top_bar_get_property;
   object_class->set_property = eos_top_bar_set_property;
-  widget_class->get_preferred_height = eos_top_bar_get_preferred_height;
-  widget_class->draw = eos_top_bar_draw;
 
   gtk_widget_class_set_template_from_resource (widget_class,
                                                "/com/endlessm/sdk/widgets/topbar.ui");
@@ -272,7 +208,10 @@ eos_top_bar_set_center_widget (EosTopBar *self,
     {
       gtk_container_add (GTK_CONTAINER (priv->center_top_bar_attach),
                          priv->center_top_bar_widget);
+      gtk_widget_show (priv->center_top_bar_attach);
       gtk_widget_show (priv->center_top_bar_widget);
+    } else {
+      gtk_widget_hide (priv->center_top_bar_attach);
     }
 }
 

--- a/endless/eoswindow.h
+++ b/endless/eoswindow.h
@@ -36,6 +36,8 @@ G_BEGIN_DECLS
   (G_TYPE_INSTANCE_GET_CLASS ((obj), \
   EOS_TYPE_WINDOW, EosWindowClass))
 
+#define EOS_WINDOW_STYLE_CLASS_INNER "eos-window-inner"
+
 typedef struct _EosWindow EosWindow;
 typedef struct _EosWindowClass EosWindowClass;
 

--- a/overrides/endless_private/topbar_home_button.js
+++ b/overrides/endless_private/topbar_home_button.js
@@ -24,17 +24,8 @@ var TopbarHomeButton = new Lang.Class({
         this.set_image(image);
 
         this.get_style_context().add_class('home');
+        this.get_style_context().add_class(Gtk.STYLE_CLASS_LINKED);
 
         this.can_focus = false;
-        this.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK);
-        this.connect('enter-notify-event', function (widget) {
-            let cursor = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
-                Gdk.CursorType.HAND1);
-            widget.window.set_cursor(cursor);
-        });
-        this.connect('leave-notify-event', function (widget) {
-            widget.window.set_cursor(null);
-        });
-        this.get_style_context().add_class(Gtk.STYLE_CLASS_LINKED);
     },
 });

--- a/overrides/endless_private/topbar_nav_button.js
+++ b/overrides/endless_private/topbar_nav_button.js
@@ -6,7 +6,7 @@ const Lang = imports.lang;
 var TopbarNavButton = new Lang.Class({
     Name: 'TopbarNavButton',
     GTypeName: 'EosTopbarNavButton',
-    Extends: Gtk.Grid,
+    Extends: Gtk.Box,
     Properties: {
         'back-button': GObject.ParamSpec.object('back-button', 'Back button',
             'Topbar back button widget',
@@ -28,29 +28,13 @@ var TopbarNavButton = new Lang.Class({
         this._forward_button = Gtk.Button.new_from_icon_name('go-next-symbolic',
             Gtk.IconSize.SMALL_TOOLBAR);
 
-        this._back_button.get_style_context().add_class('back');
-        this._forward_button.get_style_context().add_class('forward');
+        this.get_style_context().add_class(Gtk.STYLE_CLASS_LINKED);
 
         let is_rtl = (Gtk.Widget.get_default_direction() === Gtk.TextDirection.RTL);
         if (is_rtl) {
             this._back_button.get_style_context().add_class('rtl');
             this._forward_button.get_style_context().add_class('rtl');
         }
-
-        [this._back_button, this._forward_button].forEach(function (button) {
-            button.can_focus = false;
-            button.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK |
-                Gdk.EventMask.LEAVE_NOTIFY_MASK);
-            button.connect('enter-notify-event', function (widget) {
-                let cursor = Gdk.Cursor.new_for_display(Gdk.Display.get_default(),
-                    Gdk.CursorType.HAND1);
-                widget.window.set_cursor(cursor);
-            });
-            button.connect('leave-notify-event', function (widget) {
-                widget.window.set_cursor(null);
-            });
-            button.get_style_context().add_class(Gtk.STYLE_CLASS_LINKED);
-        });
 
         this.add(this._back_button);
         this.add(this._forward_button);


### PR DESCRIPTION
The purpose of this PR is to remove our custom styles for titlebars (header bars) in knowledge apps. Instead, the titlebars will look and feel like regular GNOME applications. Our custom styles should work as usual for the remaining content.

https://phabricator.endlessm.com/T21463