### PR TITLE
Remove deprecated gdk_screen_get_width/height

### DIFF
--- a/docs/reference/endless/endless-sections.txt
+++ b/docs/reference/endless/endless-sections.txt
@@ -8,7 +8,6 @@ eos_hello_sample_function
 EOS_SDK_MAJOR_VERSION
 EOS_SDK_MINOR_VERSION
 EOS_SDK_MICRO_VERSION
-eos_is_composite_tv_monitor
 eos_is_composite_tv_screen
 <SUBSECTION Private>
 EOS_DEFINE_ENUM_TYPE

--- a/docs/reference/endless/endless-sections.txt
+++ b/docs/reference/endless/endless-sections.txt
@@ -8,6 +8,7 @@ eos_hello_sample_function
 EOS_SDK_MAJOR_VERSION
 EOS_SDK_MINOR_VERSION
 EOS_SDK_MICRO_VERSION
+eos_is_composite_tv_monitor
 eos_is_composite_tv_screen
 <SUBSECTION Private>
 EOS_DEFINE_ENUM_TYPE

--- a/endless/endless.h
+++ b/endless/endless.h
@@ -29,9 +29,6 @@ gboolean eos_hello_sample_function (GFile   *file,
 EOS_SDK_DEPRECATED_IN_0_6
 gboolean        eos_is_composite_tv_screen (GdkScreen *screen);
 
-EOS_SDK_AVAILABLE_IN_0_6
-gboolean        eos_is_composite_tv_monitor (GdkMonitor *monitor);
-
 G_END_DECLS
 
 #endif

--- a/endless/endless.h
+++ b/endless/endless.h
@@ -26,8 +26,11 @@ EOS_SDK_DEPRECATED_IN_0_0
 gboolean eos_hello_sample_function (GFile   *file,
                                     GError **error);
 
-EOS_SDK_AVAILABLE_IN_0_6
+EOS_SDK_DEPRECATED_IN_0_6
 gboolean        eos_is_composite_tv_screen (GdkScreen *screen);
+
+EOS_SDK_AVAILABLE_IN_0_6
+gboolean        eos_is_composite_tv_monitor (GdkMonitor *monitor);
 
 G_END_DECLS
 

--- a/endless/eosutil.c
+++ b/endless/eosutil.c
@@ -3,47 +3,6 @@
 #include "endless.h"
 
 /**
- * eos_is_composite_tv_monitor:
- * @monitor: (allow-none): a #GdkMonitor, or %NULL to use the default display's primary monitor.
- *
- * Determines whether @monitor is a composite TV out.
- *
- * Returns: %TRUE if @monitor is a composite TV, otherwise %FALSE.
- *
- * Since: 0.6
- */
-gboolean
-eos_is_composite_tv_monitor (GdkMonitor *monitor)
-{
-  GdkDisplay *gdk_display = gdk_display_get_default ();
-
-  if (monitor == NULL)
-    monitor = gdk_display_get_primary_monitor (gdk_display);
-
-  if (monitor == NULL)
-    monitor = gdk_display_get_monitor (gdk_display, 0);
-
-  if (monitor == NULL)
-    return FALSE;
-
-  GdkRectangle geom;
-  gdk_monitor_get_geometry (monitor, &geom);
-
-  int scale = gdk_monitor_get_scale_factor (monitor);
-  int device_width_px = geom.width * scale;
-  int device_height_px = geom.height * scale;
-
-  if (device_width_px != 720)
-    return FALSE;
-
-  if (device_height_px != 480 && device_height_px != 576)
-    return FALSE;
-
-  g_debug ("Composite screen detected for monitor %p", monitor);
-  return TRUE;
-}
-
-/**
  * eos_is_composite_tv_screen:
  * @screen: (allow-none): a #GdkScreen, or %NULL to use the default display's default screen.
  *
@@ -56,16 +15,7 @@ eos_is_composite_tv_monitor (GdkMonitor *monitor)
 gboolean
 eos_is_composite_tv_screen (GdkScreen *screen)
 {
-  if (screen == NULL)
-    screen = gdk_screen_get_default ();
-
-  if (gdk_screen_get_width (screen) != 720)
-    return FALSE;
-
-  int height = gdk_screen_get_height (screen);
-  if (height != 480 && height != 576)
-    return FALSE;
-
-  g_debug ("Composite screen detected for screen %p", screen);
-  return TRUE;
+  // Composite mode support has been removed from Endless OS
+  // <https://phabricator.endlessm.com/T22102>
+  return FALSE;
 }

--- a/endless/eosutil.c
+++ b/endless/eosutil.c
@@ -3,6 +3,47 @@
 #include "endless.h"
 
 /**
+ * eos_is_composite_tv_monitor:
+ * @monitor: (allow-none): a #GdkMonitor, or %NULL to use the default display's primary monitor.
+ *
+ * Determines whether @monitor is a composite TV out.
+ *
+ * Returns: %TRUE if @monitor is a composite TV, otherwise %FALSE.
+ *
+ * Since: 0.6
+ */
+gboolean
+eos_is_composite_tv_monitor (GdkMonitor *monitor)
+{
+  GdkDisplay *gdk_display = gdk_display_get_default ();
+
+  if (monitor == NULL)
+    monitor = gdk_display_get_primary_monitor (gdk_display);
+
+  if (monitor == NULL)
+    monitor = gdk_display_get_monitor (gdk_display, 0);
+
+  if (monitor == NULL)
+    return FALSE;
+
+  GdkRectangle geom;
+  gdk_monitor_get_geometry (monitor, &geom);
+
+  int scale = gdk_monitor_get_scale_factor (monitor);
+  int device_width_px = geom.width * scale;
+  int device_height_px = geom.height * scale;
+
+  if (device_width_px != 720)
+    return FALSE;
+
+  if (device_height_px != 480 && device_height_px != 576)
+    return FALSE;
+
+  g_debug ("Composite screen detected for monitor %p", monitor);
+  return TRUE;
+}
+
+/**
  * eos_is_composite_tv_screen:
  * @screen: (allow-none): a #GdkScreen, or %NULL to use the default display's default screen.
  *

--- a/endless/eoswindow.c
+++ b/endless/eoswindow.c
@@ -122,7 +122,6 @@ typedef struct {
   gint width;
   gint height;
 
-  GdkMonitor *monitor;
 } EosWindowPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (EosWindow, eos_window, GTK_TYPE_APPLICATION_WINDOW)
@@ -690,38 +689,6 @@ eos_window_class_init (EosWindowClass *klass)
   g_object_class_install_properties (object_class, NPROPS, eos_window_props);
 }
 
-static void
-update_monitor (EosWindow *self)
-{
-  EosWindowPrivate *priv = eos_window_get_instance_private (self);
-
-  GdkWindow *gdk_window = gtk_widget_get_window (GTK_WIDGET (self));
-  if (gdk_window == NULL)
-    return;
-
-  GdkDisplay *gdk_display = gdk_window_get_display (gdk_window);
-  GdkMonitor *gdk_monitor = gdk_display_get_monitor_at_window (gdk_display,
-                                                               gdk_window);
-
-  if (priv->monitor != gdk_monitor)
-    priv->monitor = gdk_monitor;
-  else
-    return;
-
-  GtkStyleContext *context = gtk_widget_get_style_context (GTK_WIDGET (self));
-
-  if (eos_is_composite_tv_monitor (gdk_monitor))
-    gtk_style_context_add_class (context, EOS_STYLE_CLASS_COMPOSITE);
-  else
-    gtk_style_context_remove_class (context, EOS_STYLE_CLASS_COMPOSITE);
-}
-
-static void
-on_size_allocate (EosWindow *self)
-{
-  update_monitor(self);
-}
-
 #ifdef USE_METRICS
 
 static gboolean
@@ -863,9 +830,6 @@ eos_window_init (EosWindow *self)
 
   gtk_window_maximize (GTK_WINDOW (self));
   gtk_window_set_default_size (GTK_WINDOW (self), DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT);
-
-  g_signal_connect (self, "realize", G_CALLBACK (update_monitor), NULL);
-  g_signal_connect (self, "size-allocate", G_CALLBACK (on_size_allocate), NULL);
 
   g_signal_connect (priv->top_bar, "credits-clicked",
                     G_CALLBACK (on_credits_clicked), self);


### PR DESCRIPTION
To achieve this, eos_is_composite_tv_screen is replaced with a
GdkMonitor equivalent: eos_is_composite_tv_monitor.

With this change, it is possible for EosWindow to better detect the
physical monitor it is displayed on and adapt accordingly. However,
the existing code in eoswindow.c does not make use of this
functionality.

https://phabricator.endlessm.com/T28284